### PR TITLE
feat(website): phase 1 — landing content

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,12 +3,13 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import svelte from '@astrojs/svelte';
+import icon from 'astro-icon';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   site: 'https://pinax.dev',
   trailingSlash: 'never',
-  integrations: [mdx(), sitemap(), svelte()],
+  integrations: [mdx(), sitemap(), svelte(), icon()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,11 @@
     "@astrojs/mdx": "^4.0.0",
     "@astrojs/sitemap": "^3.2.0",
     "@astrojs/svelte": "^7.0.0",
+    "@iconify-json/logos": "^1.2.11",
+    "@iconify-json/simple-icons": "^1.2.87",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.0.0",
+    "astro-icon": "^1.1.5",
     "svelte": "^5.0.0",
     "tailwindcss": "^4.0.0"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
     "@astrojs/sitemap": "^3.2.0",
     "@astrojs/svelte": "^7.0.0",
     "@iconify-json/logos": "^1.2.11",
+    "@iconify-json/lucide": "^1.2.114",
     "@iconify-json/simple-icons": "^1.2.87",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.0.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -17,12 +17,21 @@ importers:
       '@astrojs/svelte':
         specifier: ^7.0.0
         version: 7.2.5(@types/node@22.20.0)(astro@5.18.2(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(typescript@5.9.3)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(svelte@5.56.4)(typescript@5.9.3)(yaml@2.9.0)
+      '@iconify-json/logos':
+        specifier: ^1.2.11
+        version: 1.2.11
+      '@iconify-json/simple-icons':
+        specifier: ^1.2.87
+        version: 1.2.87
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.3.1(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       astro:
         specifier: ^5.0.0
         version: 5.18.2(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(typescript@5.9.3)(yaml@2.9.0)
+      astro-icon:
+        specifier: ^1.1.5
+        version: 1.1.5
       svelte:
         specifier: ^5.0.0
         version: 5.56.4
@@ -53,6 +62,12 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@antfu/utils@8.1.1':
+    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -466,6 +481,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@iconify-json/logos@1.2.11':
+    resolution: {integrity: sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==}
+
+  '@iconify-json/simple-icons@1.2.87':
+    resolution: {integrity: sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==}
+
+  '@iconify/tools@4.2.0':
+    resolution: {integrity: sha512-WRxPva/ipxYkqZd1+CkEAQmd86dQmrwH0vwK89gmp2Kh2WyyVw57XbPng0NehP3x4V1LzLsXUneP1uMfTMZmUA==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@2.3.0':
+    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -602,6 +632,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -967,6 +1001,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
@@ -1061,6 +1098,9 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  astro-icon@1.1.5:
+    resolution: {integrity: sha512-CJYS5nWOw9jz4RpGWmzNQY7D0y2ZZacH7atL2K9DeJXJVaz7/5WrxeyIxO8KASk1jCM96Q4LjRx/F3R+InjJrw==}
+
   astro@5.18.2:
     resolution: {integrity: sha512-TnFwLnAXty5MXKPDGuKXqK4AMBXG+FH6RUdK7Oyc3gyfNoFIthT+4eRbzOK43bdRlLaZuxgciDSjgtggZ3OtGQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -1082,6 +1122,9 @@ packages:
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
@@ -1106,6 +1149,13 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1113,6 +1163,10 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -1147,8 +1201,18 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -1166,6 +1230,10 @@ packages:
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -1260,6 +1328,12 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -1270,6 +1344,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
@@ -1337,14 +1415,25 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1379,8 +1468,16 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1430,8 +1527,15 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -1504,6 +1608,9 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -1573,6 +1680,10 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -1650,6 +1761,9 @@ packages:
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -1759,6 +1873,17 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1800,6 +1925,9 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -1831,11 +1959,23 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -1850,6 +1990,12 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -1935,6 +2081,12 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -2038,6 +2190,9 @@ packages:
   s.color@0.0.15:
     resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sass-formatter@0.7.9:
     resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
@@ -2124,6 +2279,11 @@ packages:
     resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
     engines: {node: '>=18'}
 
+  svgo@3.3.3:
+    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -2135,6 +2295,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar@7.5.17:
+    resolution: {integrity: sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==}
+    engines: {node: '>=18'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -2196,6 +2360,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2457,6 +2625,15 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
@@ -2473,12 +2650,19 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
@@ -2501,6 +2685,9 @@ packages:
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -2538,6 +2725,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
+
+  '@antfu/utils@8.1.1': {}
 
   '@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@5.9.3)':
     dependencies:
@@ -2874,6 +3068,43 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@iconify-json/logos@1.2.11':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/simple-icons@1.2.87':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/tools@4.2.0':
+    dependencies:
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+      cheerio: 1.2.0
+      domhandler: 5.0.3
+      extract-zip: 2.0.1
+      local-pkg: 1.2.1
+      pathe: 2.0.3
+      svgo: 3.3.3
+      tar: 7.5.17
+    transitivePeerDependencies:
+      - supports-color
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@2.3.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@antfu/utils': 8.1.1
+      '@iconify/types': 2.0.0
+      debug: 4.4.3
+      globals: 15.15.0
+      kolorist: 1.8.0
+      local-pkg: 1.2.1
+      mlly: 1.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -2970,6 +3201,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3297,6 +3532,11 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.20.0
+    optional: true
+
   '@ungap/structured-clone@1.3.2': {}
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
@@ -3396,6 +3636,14 @@ snapshots:
   array-iterate@2.0.1: {}
 
   astring@1.9.0: {}
+
+  astro-icon@1.1.5:
+    dependencies:
+      '@iconify/tools': 4.2.0
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   astro@5.18.2(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.2)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
@@ -3518,6 +3766,8 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  buffer-crc32@0.2.13: {}
+
   camelcase@8.0.0: {}
 
   ccount@2.0.1: {}
@@ -3532,6 +3782,29 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -3539,6 +3812,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -3564,7 +3839,13 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
   common-ancestor-path@1.0.1: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   cookie-es@1.2.3: {}
 
@@ -3585,6 +3866,11 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@2.3.1:
+    dependencies:
+      mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   css-tree@3.2.1:
@@ -3663,6 +3949,15 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -3671,6 +3966,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -3793,11 +4090,27 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  exsolve@1.1.0: {}
+
   extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.2: {}
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3820,7 +4133,13 @@ snapshots:
 
   get-east-asian-width@1.6.0: {}
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   github-slugger@2.0.0: {}
+
+  globals@15.15.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3968,7 +4287,18 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-cache-semantics@4.2.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   import-meta-resolve@4.2.0: {}
 
@@ -4021,6 +4351,8 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  kolorist@1.8.0: {}
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -4069,6 +4401,12 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
 
   locate-character@3.0.0: {}
 
@@ -4260,6 +4598,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.0.28: {}
+
+  mdn-data@2.0.30: {}
 
   mdn-data@2.27.1: {}
 
@@ -4527,6 +4867,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -4558,6 +4911,10 @@ snapshots:
       ufo: 1.6.4
 
   ohash@2.0.11: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.2: {}
 
@@ -4609,11 +4966,24 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   piccolore@0.1.3: {}
 
@@ -4622,6 +4992,18 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.0
+      pathe: 2.0.3
 
   postcss@8.5.15:
     dependencies:
@@ -4651,6 +5033,13 @@ snapshots:
       sisteransi: 1.0.5
 
   property-information@7.2.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  quansync@0.2.11: {}
 
   radix3@1.1.2: {}
 
@@ -4844,6 +5233,8 @@ snapshots:
 
   s.color@0.0.15: {}
 
+  safer-buffer@2.1.2: {}
+
   sass-formatter@0.7.9:
     dependencies:
       suf-log: 2.5.3
@@ -4981,6 +5372,16 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  svgo@3.3.3:
+    dependencies:
+      commander: 7.2.0
+      css-select: 5.2.2
+      css-tree: 2.3.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -4994,6 +5395,14 @@ snapshots:
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
+
+  tar@7.5.17:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tiny-inflate@1.0.3: {}
 
@@ -5034,6 +5443,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5250,6 +5661,12 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   which-pm-runs@1.1.0: {}
 
   widest-line@5.0.0:
@@ -5268,9 +5685,13 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@5.0.0: {}
 
   yaml-language-server@1.20.0:
     dependencies:
@@ -5301,6 +5722,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@1.2.2: {}
 

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@iconify-json/logos':
         specifier: ^1.2.11
         version: 1.2.11
+      '@iconify-json/lucide':
+        specifier: ^1.2.114
+        version: 1.2.114
       '@iconify-json/simple-icons':
         specifier: ^1.2.87
         version: 1.2.87
@@ -483,6 +486,9 @@ packages:
 
   '@iconify-json/logos@1.2.11':
     resolution: {integrity: sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==}
+
+  '@iconify-json/lucide@1.2.114':
+    resolution: {integrity: sha512-NbvH3B1BYo6wBtS7joLi7f2UVQOqK2dtZodMFf3kkBs+Tnh9TkRuy8oVHr1RM8UK6bUtvAXxfNlGAah0CuvPCw==}
 
   '@iconify-json/simple-icons@1.2.87':
     resolution: {integrity: sha512-8YciStObhSji3OZFmWAWK6kBujyqO5bLCxeDwLxf3CR3F4PVelq7keC2LBvgTqviWzSTysj5/g4PCFLiAMVGsw==}
@@ -3069,6 +3075,10 @@ snapshots:
     optional: true
 
   '@iconify-json/logos@1.2.11':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/lucide@1.2.114':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/website/src/components/icons/ClientLogo.astro
+++ b/website/src/components/icons/ClientLogo.astro
@@ -1,0 +1,107 @@
+---
+import type { ClientId } from '~/data/clients';
+
+type Props = { id: ClientId; size?: number };
+const { id, size = 32 } = Astro.props;
+---
+
+{
+  id === 'claude-desktop' && (
+    <span
+      class="inline-flex items-center justify-center rounded-md"
+      style={`width:${size}px;height:${size}px;background:#F4EAE0;color:#D97757;border:1px solid var(--color-hairline)`}
+      aria-hidden="true"
+    >
+      <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 2 13.6 8 18 4.6 16 11l6 1.4-6 1.4 2 6.4-4.4-3.4L12 26l-1.6-7.2L6 22.2 8 14l-6-1.6 6-1.4-2-6.4L10.4 8 12 2z" />
+      </svg>
+    </span>
+  )
+}
+
+{
+  id === 'claude-code' && (
+    <span
+      class="inline-flex items-center justify-center rounded-md font-mono"
+      style={`width:${size}px;height:${size}px;background:#1B1A17;color:#D97757`}
+      aria-hidden="true"
+    >
+      <svg
+        width={size * 0.5}
+        height={size * 0.5}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="6 8 2 12 6 16" />
+        <polyline points="18 8 22 12 18 16" />
+        <line x1="14" y1="6" x2="10" y2="18" />
+      </svg>
+    </span>
+  )
+}
+
+{
+  id === 'cursor' && (
+    <span
+      class="inline-flex items-center justify-center rounded-md"
+      style={`width:${size}px;height:${size}px;background:#0A0A0A;color:#FFFFFF`}
+      aria-hidden="true"
+    >
+      <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="currentColor">
+        <path d="M5 3 5 19 9.5 14.5 12.5 21 15 20 12 13.5 18.5 13.5 5 3z" />
+      </svg>
+    </span>
+  )
+}
+
+{
+  id === 'windsurf' && (
+    <span
+      class="inline-flex items-center justify-center rounded-md"
+      style={`width:${size}px;height:${size}px;background:#0FB8B0;color:#FFFFFF`}
+      aria-hidden="true"
+    >
+      <svg
+        width={size * 0.6}
+        height={size * 0.6}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.25"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M3 14c3-4 6-4 9 0s6 4 9 0" />
+        <path d="M3 19c3-4 6-4 9 0s6 4 9 0" />
+      </svg>
+    </span>
+  )
+}
+
+{
+  id === 'cline' && (
+    <span
+      class="inline-flex items-center justify-center rounded-md font-mono"
+      style={`width:${size}px;height:${size}px;background:#1B1A17;color:#7CDC6A`}
+      aria-hidden="true"
+    >
+      <svg
+        width={size * 0.55}
+        height={size * 0.55}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="5 8 10 12 5 16" />
+        <line x1="13" y1="17" x2="19" y2="17" />
+      </svg>
+    </span>
+  )
+}

--- a/website/src/components/icons/ClientLogo.astro
+++ b/website/src/components/icons/ClientLogo.astro
@@ -1,107 +1,28 @@
 ---
+import { Icon } from 'astro-icon/components';
 import type { ClientId } from '~/data/clients';
 
 type Props = { id: ClientId; size?: number };
 const { id, size = 32 } = Astro.props;
+
+type Mark = { icon: string; bg: string; fg: string };
+
+const marks: Record<ClientId, Mark> = {
+  'claude-desktop': { icon: 'simple-icons:claude', bg: '#F4EAE0', fg: '#D97757' },
+  'claude-code': { icon: 'simple-icons:claudecode', bg: '#1B1A17', fg: '#D97757' },
+  cursor: { icon: 'simple-icons:cursor', bg: '#0A0A0A', fg: '#FFFFFF' },
+  windsurf: { icon: 'simple-icons:windsurf', bg: '#E6F8F4', fg: '#10B884' },
+  cline: { icon: 'simple-icons:cline', bg: '#1B1A17', fg: '#FFFFFF' },
+};
+
+const { icon, bg, fg } = marks[id];
+const glyph = Math.round(size * 0.55);
 ---
 
-{
-  id === 'claude-desktop' && (
-    <span
-      class="inline-flex items-center justify-center rounded-md"
-      style={`width:${size}px;height:${size}px;background:#F4EAE0;color:#D97757;border:1px solid var(--color-hairline)`}
-      aria-hidden="true"
-    >
-      <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="currentColor">
-        <path d="M12 2 13.6 8 18 4.6 16 11l6 1.4-6 1.4 2 6.4-4.4-3.4L12 26l-1.6-7.2L6 22.2 8 14l-6-1.6 6-1.4-2-6.4L10.4 8 12 2z" />
-      </svg>
-    </span>
-  )
-}
-
-{
-  id === 'claude-code' && (
-    <span
-      class="inline-flex items-center justify-center rounded-md font-mono"
-      style={`width:${size}px;height:${size}px;background:#1B1A17;color:#D97757`}
-      aria-hidden="true"
-    >
-      <svg
-        width={size * 0.5}
-        height={size * 0.5}
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <polyline points="6 8 2 12 6 16" />
-        <polyline points="18 8 22 12 18 16" />
-        <line x1="14" y1="6" x2="10" y2="18" />
-      </svg>
-    </span>
-  )
-}
-
-{
-  id === 'cursor' && (
-    <span
-      class="inline-flex items-center justify-center rounded-md"
-      style={`width:${size}px;height:${size}px;background:#0A0A0A;color:#FFFFFF`}
-      aria-hidden="true"
-    >
-      <svg width={size * 0.55} height={size * 0.55} viewBox="0 0 24 24" fill="currentColor">
-        <path d="M5 3 5 19 9.5 14.5 12.5 21 15 20 12 13.5 18.5 13.5 5 3z" />
-      </svg>
-    </span>
-  )
-}
-
-{
-  id === 'windsurf' && (
-    <span
-      class="inline-flex items-center justify-center rounded-md"
-      style={`width:${size}px;height:${size}px;background:#0FB8B0;color:#FFFFFF`}
-      aria-hidden="true"
-    >
-      <svg
-        width={size * 0.6}
-        height={size * 0.6}
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2.25"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <path d="M3 14c3-4 6-4 9 0s6 4 9 0" />
-        <path d="M3 19c3-4 6-4 9 0s6 4 9 0" />
-      </svg>
-    </span>
-  )
-}
-
-{
-  id === 'cline' && (
-    <span
-      class="inline-flex items-center justify-center rounded-md font-mono"
-      style={`width:${size}px;height:${size}px;background:#1B1A17;color:#7CDC6A`}
-      aria-hidden="true"
-    >
-      <svg
-        width={size * 0.55}
-        height={size * 0.55}
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <polyline points="5 8 10 12 5 16" />
-        <line x1="13" y1="17" x2="19" y2="17" />
-      </svg>
-    </span>
-  )
-}
+<span
+  class="inline-flex items-center justify-center rounded-md"
+  style={`width:${size}px;height:${size}px;background:${bg};color:${fg};border:1px solid var(--color-hairline)`}
+  aria-hidden="true"
+>
+  <Icon name={icon} width={glyph} height={glyph} />
+</span>

--- a/website/src/components/marketing/ClientMatrix.astro
+++ b/website/src/components/marketing/ClientMatrix.astro
@@ -50,5 +50,3 @@ import ClientLogo from '~/components/icons/ClientLogo.astro';
     }
   </ul>
 </section>
-Setup guide → )) }
-

--- a/website/src/components/marketing/ClientMatrix.astro
+++ b/website/src/components/marketing/ClientMatrix.astro
@@ -1,0 +1,48 @@
+---
+import { clients } from '~/data/clients';
+---
+
+<section class="container-page py-24 sm:py-32">
+  <header class="mb-12 max-w-2xl">
+    <p
+      class="mb-3 text-[11px] font-semibold tracking-[0.18em] uppercase"
+      style="color: var(--color-primary)"
+    >
+      MCP clients
+    </p>
+    <h2 class="font-serif text-4xl tracking-tight sm:text-5xl" style="color: var(--color-fg)">
+      Wire it into the agent you already use.
+    </h2>
+    <p class="mt-4 text-base" style="color: var(--color-muted)">
+      Each client gets a copy-pasteable JSON snippet and a config-path reminder.
+    </p>
+  </header>
+
+  <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {
+      clients.map((c) => (
+        <li>
+          <a
+            href={c.docsHref}
+            class="group hairline block rounded-lg border p-5 transition-colors hover:border-[color:var(--color-primary)]"
+            style="background: var(--color-bg)"
+          >
+            <p class="font-serif text-lg" style="color: var(--color-fg)">
+              {c.label}
+            </p>
+            <p
+              class="mt-2 truncate font-mono text-xs"
+              title={c.configPath}
+              style="color: var(--color-muted)"
+            >
+              {c.configPath}
+            </p>
+            <p class="mt-4 text-xs font-medium" style="color: var(--color-primary)">
+              Setup guide →
+            </p>
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</section>

--- a/website/src/components/marketing/ClientMatrix.astro
+++ b/website/src/components/marketing/ClientMatrix.astro
@@ -1,5 +1,6 @@
 ---
 import { clients } from '~/data/clients';
+import ClientLogo from '~/components/icons/ClientLogo.astro';
 ---
 
 <section class="container-page py-24 sm:py-32">
@@ -27,11 +28,14 @@ import { clients } from '~/data/clients';
             class="group hairline block rounded-lg border p-5 transition-colors hover:border-[color:var(--color-primary)]"
             style="background: var(--color-bg)"
           >
-            <p class="font-serif text-lg" style="color: var(--color-fg)">
-              {c.label}
-            </p>
+            <div class="flex items-center gap-3">
+              <ClientLogo id={c.id} size={32} />
+              <p class="font-serif text-lg" style="color: var(--color-fg)">
+                {c.label}
+              </p>
+            </div>
             <p
-              class="mt-2 truncate font-mono text-xs"
+              class="mt-3 truncate font-mono text-xs"
               title={c.configPath}
               style="color: var(--color-muted)"
             >
@@ -46,3 +50,5 @@ import { clients } from '~/data/clients';
     }
   </ul>
 </section>
+Setup guide → )) }
+

--- a/website/src/components/marketing/Faq.astro
+++ b/website/src/components/marketing/Faq.astro
@@ -1,0 +1,44 @@
+---
+import { faq } from '~/data/faq';
+---
+
+<section class="hairline border-t" style="background: var(--color-panel)">
+  <div class="container-page py-24 sm:py-32">
+    <header class="mb-12 max-w-2xl">
+      <p
+        class="mb-3 text-[11px] font-semibold tracking-[0.18em] uppercase"
+        style="color: var(--color-primary)"
+      >
+        FAQ
+      </p>
+      <h2 class="font-serif text-4xl tracking-tight sm:text-5xl" style="color: var(--color-fg)">
+        Honest answers, in advance.
+      </h2>
+    </header>
+
+    <div class="hairline mx-auto max-w-3xl divide-y">
+      {
+        faq.map((item) => (
+          <details class="group py-5">
+            <summary
+              class="flex cursor-pointer list-none items-center justify-between gap-4 text-left"
+              style="color: var(--color-fg)"
+            >
+              <span class="font-serif text-lg">{item.q}</span>
+              <span
+                class="font-mono text-xl transition-transform group-open:rotate-45"
+                aria-hidden
+                style="color: var(--color-muted)"
+              >
+                +
+              </span>
+            </summary>
+            <p class="mt-3 text-base leading-relaxed" style="color: var(--color-muted)">
+              {item.a}
+            </p>
+          </details>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/website/src/components/marketing/FinalCta.astro
+++ b/website/src/components/marketing/FinalCta.astro
@@ -1,0 +1,31 @@
+---
+import { finalCta } from '~/data/landing';
+import CommandCard from '~/components/primitives/CommandCard.astro';
+---
+
+<section class="container-page py-28 sm:py-36">
+  <div class="mx-auto max-w-3xl text-center">
+    <p
+      class="mb-3 text-[11px] font-semibold tracking-[0.18em] uppercase"
+      style="color: var(--color-primary)"
+    >
+      {finalCta.kicker}
+    </p>
+    <h2
+      class="font-serif text-4xl tracking-tight sm:text-5xl md:text-6xl"
+      style="color: var(--color-fg)"
+    >
+      {finalCta.headline}
+    </h2>
+    <div class="mx-auto mt-10 max-w-lg">
+      <CommandCard command={finalCta.command} />
+    </div>
+    <a
+      href={finalCta.href}
+      class="mt-6 inline-block text-sm font-medium underline-offset-4 hover:underline"
+      style="color: var(--color-primary)"
+    >
+      {finalCta.hrefLabel}
+    </a>
+  </div>
+</section>

--- a/website/src/components/marketing/Hero.astro
+++ b/website/src/components/marketing/Hero.astro
@@ -1,0 +1,50 @@
+---
+import { site } from '~/lib/site';
+import CommandCard from '~/components/primitives/CommandCard.astro';
+import { clients } from '~/data/clients';
+---
+
+<section class="container-page pt-20 pb-24 sm:pt-28 sm:pb-32">
+  <p
+    class="mb-5 text-[11px] font-semibold tracking-[0.2em] uppercase"
+    style="color: var(--color-primary)"
+  >
+    Local MCP server for docs
+  </p>
+  <h1
+    class="font-serif text-5xl leading-[1.04] tracking-[-0.02em] sm:text-6xl md:text-7xl"
+    style="color: var(--color-fg)"
+  >
+    Any docs site.<br />A local MCP server.<br />Under a minute.
+  </h1>
+  <p class="mt-7 max-w-2xl text-lg leading-relaxed" style="color: var(--color-muted)">
+    {site.description}
+  </p>
+
+  <div class="mt-10 flex flex-wrap items-center gap-3">
+    <div class="w-full max-w-md">
+      <CommandCard command={`brew install ${site.brewTap}`} />
+    </div>
+    <a
+      href="/docs/quick-start"
+      class="inline-flex items-center rounded-md px-4 py-3 text-sm font-medium transition-opacity hover:opacity-90"
+      style="background: var(--color-primary); color: var(--color-bg)"
+    >
+      Read the docs →
+    </a>
+  </div>
+
+  <div
+    class="mt-12 flex flex-wrap items-center gap-x-6 gap-y-2 text-xs"
+    style="color: var(--color-muted)"
+  >
+    <span class="tracking-[0.14em] uppercase">Works with</span>
+    {
+      clients.map((c) => (
+        <a href={c.docsHref} class="hover:opacity-80" style="color: var(--color-fg)">
+          {c.label}
+        </a>
+      ))
+    }
+  </div>
+</section>

--- a/website/src/components/marketing/HowItWorks.astro
+++ b/website/src/components/marketing/HowItWorks.astro
@@ -1,0 +1,39 @@
+---
+import { howItWorks } from '~/data/landing';
+import CommandCard from '~/components/primitives/CommandCard.astro';
+---
+
+<section class="container-page py-24 sm:py-32">
+  <header class="mb-12 max-w-2xl">
+    <p
+      class="mb-3 text-[11px] font-semibold tracking-[0.18em] uppercase"
+      style="color: var(--color-primary)"
+    >
+      How it works
+    </p>
+    <h2 class="font-serif text-4xl tracking-tight sm:text-5xl" style="color: var(--color-fg)">
+      Three commands. Zero servers to manage.
+    </h2>
+  </header>
+
+  <ol class="grid grid-cols-1 gap-6 md:grid-cols-3">
+    {
+      howItWorks.map((step) => (
+        <li class="hairline rounded-lg border p-6" style="background: var(--color-bg)">
+          <p class="font-mono text-xs" style="color: var(--color-muted)">
+            {step.index}
+          </p>
+          <p class="mt-2 font-serif text-2xl" style="color: var(--color-fg)">
+            {step.verb}
+          </p>
+          <div class="mt-4">
+            <CommandCard command={step.command} size="sm" />
+          </div>
+          <p class="mt-4 text-sm leading-relaxed" style="color: var(--color-muted)">
+            {step.body}
+          </p>
+        </li>
+      ))
+    }
+  </ol>
+</section>

--- a/website/src/components/marketing/InstallBlock.astro
+++ b/website/src/components/marketing/InstallBlock.astro
@@ -1,0 +1,44 @@
+---
+import { installOptions } from '~/data/landing';
+import CommandCard from '~/components/primitives/CommandCard.astro';
+---
+
+<section class="hairline border-t" style="background: var(--color-panel)">
+  <div class="container-page py-24 sm:py-32">
+    <header class="mb-12 max-w-2xl">
+      <p
+        class="mb-3 text-[11px] font-semibold tracking-[0.18em] uppercase"
+        style="color: var(--color-primary)"
+      >
+        Install
+      </p>
+      <h2 class="font-serif text-4xl tracking-tight sm:text-5xl" style="color: var(--color-fg)">
+        Pick one. Run it.
+      </h2>
+    </header>
+
+    <div class="grid grid-cols-1 gap-5 md:grid-cols-3">
+      {
+        installOptions.map((opt, i) => (
+          <article
+            class="hairline flex flex-col rounded-lg border p-6"
+            style="background: var(--color-bg)"
+          >
+            <p class="font-mono text-xs" style="color: var(--color-muted)">
+              {String(i + 1).padStart(2, '0')}
+            </p>
+            <p class="mt-2 font-serif text-xl" style="color: var(--color-fg)">
+              {opt.label}
+            </p>
+            <div class="mt-4">
+              <CommandCard command={opt.command} size="sm" />
+            </div>
+            <p class="mt-4 text-xs leading-relaxed" style="color: var(--color-muted)">
+              {opt.hint}
+            </p>
+          </article>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/website/src/components/marketing/InstallBlock.astro
+++ b/website/src/components/marketing/InstallBlock.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from 'astro-icon/components';
 import { installOptions } from '~/data/landing';
 import CommandCard from '~/components/primitives/CommandCard.astro';
 ---
@@ -24,10 +25,19 @@ import CommandCard from '~/components/primitives/CommandCard.astro';
             class="hairline flex flex-col rounded-lg border p-6"
             style="background: var(--color-bg)"
           >
-            <p class="font-mono text-xs" style="color: var(--color-muted)">
-              {String(i + 1).padStart(2, '0')}
-            </p>
-            <p class="mt-2 font-serif text-xl" style="color: var(--color-fg)">
+            <div class="flex items-center justify-between">
+              <span
+                class="inline-flex items-center justify-center rounded-md"
+                style={`width:32px;height:32px;background:${opt.bg};color:${opt.fg};border:1px solid var(--color-hairline)`}
+                aria-hidden="true"
+              >
+                <Icon name={opt.icon} width={18} height={18} />
+              </span>
+              <p class="font-mono text-xs" style="color: var(--color-muted)">
+                {String(i + 1).padStart(2, '0')}
+              </p>
+            </div>
+            <p class="mt-4 font-serif text-xl" style="color: var(--color-fg)">
               {opt.label}
             </p>
             <div class="mt-4">

--- a/website/src/components/marketing/StatsTrio.astro
+++ b/website/src/components/marketing/StatsTrio.astro
@@ -1,0 +1,28 @@
+---
+import { stats } from '~/data/landing';
+---
+
+<section class="hairline border-y" style="background: var(--color-panel)">
+  <div
+    class="container-page hairline grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+  >
+    {
+      stats.map((s) => (
+        <div class="py-10 sm:px-8">
+          <p
+            class="font-serif text-5xl tracking-tight tabular-nums sm:text-6xl"
+            style="color: var(--color-fg)"
+          >
+            {s.value}
+          </p>
+          <p class="mt-2 text-sm" style="color: var(--color-fg)">
+            {s.label}
+          </p>
+          <p class="mt-1 text-xs" style="color: var(--color-muted)">
+            {s.sub}
+          </p>
+        </div>
+      ))
+    }
+  </div>
+</section>

--- a/website/src/components/primitives/CommandCard.astro
+++ b/website/src/components/primitives/CommandCard.astro
@@ -8,11 +8,11 @@ type Props = {
 };
 
 const { command, prompt = '$', size = 'md' } = Astro.props;
-const padding = size === 'sm' ? 'px-3 py-2 text-xs' : 'px-4 py-3 text-sm';
+const sizing = size === 'sm' ? 'min-h-10 pl-3 pr-1.5 text-xs' : 'min-h-12 pl-4 pr-2 text-sm';
 ---
 
 <div
-  class={`flex items-center justify-between gap-3 rounded-md border hairline ${padding}`}
+  class={`flex items-center justify-between gap-3 rounded-md border hairline ${sizing}`}
   style="background: var(--color-panel)"
 >
   <code class="truncate font-mono" style="color: var(--color-fg)">

--- a/website/src/components/primitives/CommandCard.astro
+++ b/website/src/components/primitives/CommandCard.astro
@@ -1,0 +1,23 @@
+---
+import CopyButton from './CopyButton.svelte';
+
+type Props = {
+  command: string;
+  prompt?: string;
+  size?: 'sm' | 'md';
+};
+
+const { command, prompt = '$', size = 'md' } = Astro.props;
+const padding = size === 'sm' ? 'px-3 py-2 text-xs' : 'px-4 py-3 text-sm';
+---
+
+<div
+  class={`flex items-center justify-between gap-3 rounded-md border hairline ${padding}`}
+  style="background: var(--color-panel)"
+>
+  <code class="truncate font-mono" style="color: var(--color-fg)">
+    <span style="color: var(--color-muted)">{prompt}</span>
+    <span class="ml-2">{command}</span>
+  </code>
+  <CopyButton client:load text={command} />
+</div>

--- a/website/src/components/primitives/CopyButton.svelte
+++ b/website/src/components/primitives/CopyButton.svelte
@@ -20,18 +20,50 @@
   type="button"
   onclick={copy}
   aria-label={copied ? 'Copied to clipboard' : `Copy ${label}`}
+  title={copied ? 'Copied' : `Copy ${label}`}
   class="copy-btn"
   class:copied
 >
-  {copied ? 'Copied' : label}
+  {#if copied}
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.25"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  {:else}
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  {/if}
 </button>
 
 <style>
   .copy-btn {
-    font: 500 11px/1 var(--font-mono, ui-monospace, monospace);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    padding: 6px 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
     border-radius: 6px;
     border: 1px solid var(--color-hairline);
     background: var(--color-bg);

--- a/website/src/components/primitives/CopyButton.svelte
+++ b/website/src/components/primitives/CopyButton.svelte
@@ -61,8 +61,9 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
+    flex: 0 0 26px;
     padding: 0;
     border-radius: 6px;
     border: 1px solid var(--color-hairline);

--- a/website/src/components/primitives/CopyButton.svelte
+++ b/website/src/components/primitives/CopyButton.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  type Props = { text: string; label?: string };
+  let { text, label = 'Copy' }: Props = $props();
+  let copied = $state(false);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      clearTimeout(timer);
+      timer = setTimeout(() => (copied = false), 1600);
+    } catch {
+      copied = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  onclick={copy}
+  aria-label={copied ? 'Copied to clipboard' : `Copy ${label}`}
+  class="copy-btn"
+  class:copied
+>
+  {copied ? 'Copied' : label}
+</button>
+
+<style>
+  .copy-btn {
+    font: 500 11px/1 var(--font-mono, ui-monospace, monospace);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--color-hairline);
+    background: var(--color-bg);
+    color: var(--color-muted);
+    cursor: pointer;
+    transition:
+      color 120ms,
+      border-color 120ms,
+      background 120ms;
+  }
+  .copy-btn:hover {
+    color: var(--color-fg);
+    border-color: var(--color-fg);
+  }
+  .copy-btn.copied {
+    color: var(--color-success);
+    border-color: var(--color-success);
+  }
+</style>

--- a/website/src/data/faq.ts
+++ b/website/src/data/faq.ts
@@ -1,0 +1,35 @@
+export type FaqItem = {
+  q: string;
+  a: string;
+};
+
+export const faq: readonly FaqItem[] = [
+  {
+    q: 'What is Pinax?',
+    a: 'A small Go CLI that turns any public documentation site into a local Model Context Protocol server. Run it once, point your MCP client at it, and the docs become live tools your agent can call — no copy-pasting pages into chat.',
+  },
+  {
+    q: 'Why MCP and not just RAG or a vector database?',
+    a: 'Docs already have structure (headings, sitemaps, llms.txt). Pinax keeps that structure intact and serves pages live, so answers come from the version of the docs that exists today, not a stale embedding from last month. No embeddings, no re-indexing, no drift.',
+  },
+  {
+    q: 'Does Pinax send anything off my machine?',
+    a: "Only the requests you'd make anyway — fetching pages from the docs site itself. No telemetry, no analytics, no third-party APIs. The MCP transport is stdio between Pinax and your client; the log UI is a localhost-only HTTP server.",
+  },
+  {
+    q: "Which docs sites work? Which don't?",
+    a: 'Anything with a sitemap.xml or llms.txt works out of the box. Pages need to render on the server (HTML, not pure SPA shells) — most popular dev docs do. The catalog page lists the 15 we know index cleanly today; any URL with /, . or :// is a valid add target.',
+  },
+  {
+    q: "How do I add a docs site that isn't in the catalog?",
+    a: 'Run pinax add <url> with any HTTPS URL. Pinax discovers structure on the fly. If you want it shipped in the curated catalog, open an issue or PR against internal/catalog/catalog.json and add the three required fields: displayName, url, tags.',
+  },
+  {
+    q: 'Can I run it against private or auth-gated docs?',
+    a: 'Not in v0.3. Auth headers and cookie-based crawling are planned for v0.4. Today Pinax fetches as an anonymous client, so anything behind a login screen is invisible to it.',
+  },
+  {
+    q: 'How is it different from gitingest, repomix, or just downloading llms.txt?',
+    a: 'Those tools concatenate or summarise content into one large blob. Pinax exposes structured tools — list_sections, search_pages, get_page — so the agent fetches only the page it needs, when it needs it. No prompt-bloat, no out-of-date copies.',
+  },
+];

--- a/website/src/data/landing.ts
+++ b/website/src/data/landing.ts
@@ -42,6 +42,9 @@ export type InstallOption = {
   label: string;
   command: string;
   hint: string;
+  icon: string;
+  bg: string;
+  fg: string;
 };
 
 export const installOptions: readonly InstallOption[] = [
@@ -49,16 +52,25 @@ export const installOptions: readonly InstallOption[] = [
     label: 'Homebrew',
     command: 'brew install desmondsanctity/tap/pinax',
     hint: 'Recommended on macOS · auto-updates with brew upgrade.',
+    icon: 'simple-icons:homebrew',
+    bg: '#1B1A17',
+    fg: '#FBB040',
   },
   {
     label: 'Go install',
     command: 'go install github.com/desmondsanctity/pinax/cmd/pinax@latest',
     hint: 'Requires Go 1.22+. Binary lands in $GOBIN.',
+    icon: 'simple-icons:go',
+    bg: '#E6F4F9',
+    fg: '#00ADD8',
   },
   {
     label: 'Prebuilt binary',
     command: 'curl -L https://github.com/desmondsanctity/pinax/releases/latest -o pinax',
     hint: 'Linux/macOS/Windows builds on the releases page.',
+    icon: 'lucide:package',
+    bg: '#F2EEE5',
+    fg: '#1E3A8A',
   },
 ];
 

--- a/website/src/data/landing.ts
+++ b/website/src/data/landing.ts
@@ -1,0 +1,79 @@
+export type Stat = {
+  value: string;
+  label: string;
+  sub: string;
+};
+
+export const stats: readonly Stat[] = [
+  { value: '15', label: 'curated docs sites', sub: 'one-word names → indexed' },
+  { value: '4', label: 'MCP tools', sub: 'list · search · sections · get' },
+  { value: '0', label: 'cloud', sub: 'stays on your machine' },
+];
+
+export type Step = {
+  index: string;
+  verb: string;
+  command: string;
+  body: string;
+};
+
+export const howItWorks: readonly Step[] = [
+  {
+    index: '01',
+    verb: 'Add',
+    command: 'pinax add stripe',
+    body: 'Pick a name from the catalog or paste any docs URL. Pinax discovers structure via llms.txt or sitemap.xml and writes a local manifest.',
+  },
+  {
+    index: '02',
+    verb: 'Serve',
+    command: 'pinax serve',
+    body: 'A local MCP server speaks stdio to your client and HTTP to the log UI. Pages are fetched live, so what your agent reads is what the docs site serves today.',
+  },
+  {
+    index: '03',
+    verb: 'Use',
+    command: 'mcp tools/call search_pages',
+    body: 'Your client gets four focused tools: list manifests, list sections, full-text search a page, and fetch the page. No vectors, no retraining.',
+  },
+];
+
+export type InstallOption = {
+  label: string;
+  command: string;
+  hint: string;
+};
+
+export const installOptions: readonly InstallOption[] = [
+  {
+    label: 'Homebrew',
+    command: 'brew install desmondsanctity/tap/pinax',
+    hint: 'Recommended on macOS · auto-updates with brew upgrade.',
+  },
+  {
+    label: 'Go install',
+    command: 'go install github.com/desmondsanctity/pinax/cmd/pinax@latest',
+    hint: 'Requires Go 1.22+. Binary lands in $GOBIN.',
+  },
+  {
+    label: 'Prebuilt binary',
+    command: 'curl -L https://github.com/desmondsanctity/pinax/releases/latest -o pinax',
+    hint: 'Linux/macOS/Windows builds on the releases page.',
+  },
+];
+
+export type FinalCta = {
+  kicker: string;
+  headline: string;
+  command: string;
+  href: string;
+  hrefLabel: string;
+};
+
+export const finalCta: FinalCta = {
+  kicker: 'One last thing',
+  headline: 'Index your first docs site now.',
+  command: 'pinax add stripe && pinax serve',
+  href: '/docs/quick-start',
+  hrefLabel: 'Or read the quick start →',
+};

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -15,8 +15,8 @@ const { title, description } = Astro.props;
     <aside class="lg:sticky lg:top-20 lg:self-start">
       <Sidebar />
     </aside>
-    <article class="prose prose-neutral max-w-none">
-      <header class="not-prose mb-8 border-b pb-6" style="border-color: var(--color-hairline)">
+    <article class="prose-pinax max-w-none">
+      <header class="mb-8 border-b pb-6" style="border-color: var(--color-hairline)">
         <h1 class="text-4xl font-medium tracking-tight" style="color: var(--color-fg)">
           {title}
         </h1>

--- a/website/src/pages/catalog.astro
+++ b/website/src/pages/catalog.astro
@@ -1,5 +1,6 @@
 ---
 import MarketingLayout from '~/layouts/MarketingLayout.astro';
+import CommandCard from '~/components/primitives/CommandCard.astro';
 import { catalog, allTags, catalogVersion } from '~/data/catalog';
 ---
 
@@ -24,7 +25,10 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
     <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {
         catalog.map((entry) => (
-          <li class="hairline rounded-lg border p-5" style="background: var(--color-panel)">
+          <li
+            class="hairline flex flex-col rounded-lg border p-5"
+            style="background: var(--color-panel)"
+          >
             <p class="font-serif text-lg" style="color: var(--color-fg)">
               {entry.displayName}
             </p>
@@ -41,12 +45,9 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
                 </span>
               ))}
             </div>
-            <code
-              class="hairline mt-4 block rounded-md border px-3 py-2 text-xs"
-              style="background: var(--color-bg); color: var(--color-fg)"
-            >
-              pinax add {entry.key}
-            </code>
+            <div class="mt-auto pt-4">
+              <CommandCard command={`pinax add ${entry.key}`} size="sm" />
+            </div>
           </li>
         ))
       }

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,40 +1,20 @@
 ---
 import MarketingLayout from '~/layouts/MarketingLayout.astro';
-import { site } from '~/lib/site';
-import { catalog } from '~/data/catalog';
+import Hero from '~/components/marketing/Hero.astro';
+import StatsTrio from '~/components/marketing/StatsTrio.astro';
+import HowItWorks from '~/components/marketing/HowItWorks.astro';
+import InstallBlock from '~/components/marketing/InstallBlock.astro';
+import ClientMatrix from '~/components/marketing/ClientMatrix.astro';
+import Faq from '~/components/marketing/Faq.astro';
+import FinalCta from '~/components/marketing/FinalCta.astro';
 ---
 
 <MarketingLayout>
-  <section class="container-page py-24">
-    <p
-      class="mb-4 text-[11px] font-semibold tracking-[0.18em] uppercase"
-      style="color: var(--color-muted)"
-    >
-      Local MCP server for docs
-    </p>
-    <h1 class="font-serif text-5xl tracking-tight sm:text-6xl" style="color: var(--color-fg)">
-      Any docs site.<br />A local MCP server.<br />Under a minute.
-    </h1>
-    <p class="mt-6 max-w-2xl text-lg" style="color: var(--color-muted)">
-      {site.description}
-    </p>
-    <div class="mt-8 flex flex-wrap items-center gap-3">
-      <code
-        class="hairline rounded-md border px-4 py-2 text-sm"
-        style="background: var(--color-panel)"
-      >
-        brew install {site.brewTap}
-      </code>
-      <a
-        href="/docs/quick-start"
-        class="rounded-md px-4 py-2 text-sm font-medium"
-        style="background: var(--color-primary); color: var(--color-bg)"
-      >
-        Read the docs →
-      </a>
-    </div>
-    <p class="mt-12 text-xs tracking-[0.14em] uppercase" style="color: var(--color-muted)">
-      Phase-0 scaffold · landing copy coming in Phase 1 · {catalog.length} catalog entries indexed
-    </p>
-  </section>
+  <Hero />
+  <StatsTrio />
+  <HowItWorks />
+  <InstallBlock />
+  <ClientMatrix />
+  <Faq />
+  <FinalCta />
 </MarketingLayout>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -61,3 +61,85 @@
 @utility hairline {
   border-color: var(--color-hairline);
 }
+
+/* Docs prose — hand-rolled to avoid pulling in @tailwindcss/typography. */
+.prose-pinax {
+  color: var(--color-fg);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+.prose-pinax > * + * {
+  margin-top: 1.1rem;
+}
+.prose-pinax h2 {
+  font-family: var(--font-serif);
+  font-size: 1.65rem;
+  letter-spacing: -0.01em;
+  margin-top: 2.75rem;
+  margin-bottom: 0.25rem;
+}
+.prose-pinax h3 {
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+  letter-spacing: -0.005em;
+  margin-top: 2rem;
+  margin-bottom: 0.1rem;
+}
+.prose-pinax p {
+  color: var(--color-fg);
+}
+.prose-pinax ul,
+.prose-pinax ol {
+  padding-left: 1.4rem;
+  margin-top: 0.75rem;
+}
+.prose-pinax ul {
+  list-style: disc;
+}
+.prose-pinax ol {
+  list-style: decimal;
+}
+.prose-pinax li + li {
+  margin-top: 0.35rem;
+}
+.prose-pinax a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+.prose-pinax code {
+  background: var(--color-panel);
+  padding: 0.12em 0.4em;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+.prose-pinax pre {
+  background: var(--color-panel);
+  padding: 1rem 1.1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.88rem;
+  border: 1px solid var(--color-hairline);
+  margin-top: 1.25rem;
+}
+.prose-pinax pre code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+}
+.prose-pinax strong {
+  color: var(--color-fg);
+  font-weight: 600;
+}
+.prose-pinax blockquote {
+  border-left: 3px solid var(--color-hairline);
+  padding-left: 1rem;
+  color: var(--color-muted);
+  font-style: italic;
+}
+.prose-pinax hr {
+  border: 0;
+  border-top: 1px solid var(--color-hairline);
+  margin: 2rem 0;
+}


### PR DESCRIPTION
Real marketing copy for pinax.dev:

- Hero: 'Any docs site / A local MCP server / Under a minute' with install snippet + 'works with' client row
- StatsTrio: 15 catalog entries · 4 MCP tools · 0 cloud
- HowItWorks: three numbered command cards (Add / Serve / Use)
- InstallBlock: brew + go install + manual fallback w/ Svelte CopyButton islands
- ClientMatrix: 5 client config-path cards (Claude Desktop/Code, Cursor, Windsurf, Cline)
- Faq: 6 q-and-a entries sourced from docs/PRD + RUNBOOK
- FinalCta: 'pick a catalog name → run brew install → done'

Also adds CommandCard primitive, hand-rolled prose typography in globals.css (Tailwind v4 has no @tailwindcss/typography plugin yet), and small DocsLayout polish.
