### PR TITLE
Site/phase 2

### DIFF
--- a/website/src/components/catalog/CatalogFilter.svelte
+++ b/website/src/components/catalog/CatalogFilter.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  type Props = { tags: readonly string[]; total: number };
+  let { tags, total }: Props = $props();
+
+  let query = $state('');
+  let selected: Set<string> = $state(new Set());
+  let visible = $state(total);
+
+  function toggle(tag: string) {
+    const next = new Set(selected);
+    if (next.has(tag)) next.delete(tag);
+    else next.add(tag);
+    selected = next;
+  }
+
+  function clear() {
+    query = '';
+    selected = new Set();
+  }
+
+  function apply() {
+    const q = query.trim().toLowerCase();
+    const sel = selected;
+    let count = 0;
+    document.querySelectorAll<HTMLElement>('[data-catalog-card]').forEach((el) => {
+      const search = (el.dataset['search'] ?? '').toLowerCase();
+      const cardTags = (el.dataset['tags'] ?? '').split(' ').filter(Boolean);
+      const matchSearch = q === '' || search.includes(q);
+      const matchTags = sel.size === 0 || cardTags.some((t) => sel.has(t));
+      const show = matchSearch && matchTags;
+      el.hidden = !show;
+      if (show) count++;
+    });
+    visible = count;
+    const empty = document.querySelector<HTMLElement>('[data-catalog-empty]');
+    if (empty) empty.hidden = count > 0;
+  }
+
+  $effect(() => {
+    void query;
+    void selected;
+    apply();
+  });
+
+  const hasFilter = $derived(query.trim() !== '' || selected.size > 0);
+</script>
+
+<div class="filter">
+  <div class="search-row">
+    <svg
+      class="search-icon"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+    <input
+      type="search"
+      bind:value={query}
+      placeholder="Search by name, tag, or URL…"
+      aria-label="Search catalog"
+    />
+    {#if hasFilter}
+      <button type="button" class="clear" onclick={clear}>Clear</button>
+    {/if}
+  </div>
+
+  <div class="chips" role="group" aria-label="Filter by tag">
+    {#each tags as tag}
+      <button
+        type="button"
+        class="chip"
+        class:active={selected.has(tag)}
+        aria-pressed={selected.has(tag)}
+        onclick={() => toggle(tag)}
+      >
+        {tag}
+      </button>
+    {/each}
+  </div>
+
+  <p class="count">
+    {visible} of {total}
+    {total === 1 ? 'entry' : 'entries'}
+  </p>
+</div>
+
+<style>
+  .filter {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .search-row {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .search-icon {
+    position: absolute;
+    left: 12px;
+    color: var(--color-muted);
+    pointer-events: none;
+  }
+  input[type='search'] {
+    flex: 1;
+    padding: 10px 12px 10px 36px;
+    border: 1px solid var(--color-hairline);
+    border-radius: 8px;
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font: 400 14px/1.4 var(--font-sans);
+    outline: none;
+    transition:
+      border-color 120ms,
+      box-shadow 120ms;
+  }
+  input[type='search']:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 16%, transparent);
+  }
+  .clear {
+    padding: 8px 12px;
+    border: 1px solid var(--color-hairline);
+    border-radius: 8px;
+    background: var(--color-bg);
+    color: var(--color-muted);
+    font: 500 12px/1 var(--font-sans);
+    cursor: pointer;
+    transition:
+      color 120ms,
+      border-color 120ms;
+  }
+  .clear:hover {
+    color: var(--color-fg);
+    border-color: var(--color-fg);
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    padding: 4px 10px;
+    border: 1px solid var(--color-hairline);
+    border-radius: 999px;
+    background: var(--color-bg);
+    color: var(--color-muted);
+    font: 500 10px/1 var(--font-sans);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition:
+      color 120ms,
+      border-color 120ms,
+      background 120ms;
+  }
+  .chip:hover {
+    color: var(--color-fg);
+    border-color: var(--color-fg);
+  }
+  .chip.active {
+    color: var(--color-bg);
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+  .count {
+    font: 500 11px/1 var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--color-muted);
+  }
+</style>

--- a/website/src/components/icons/CatalogLogo.astro
+++ b/website/src/components/icons/CatalogLogo.astro
@@ -1,0 +1,38 @@
+---
+import { Icon } from 'astro-icon/components';
+
+type Props = { entryKey: string; size?: number };
+const { entryKey, size = 32 } = Astro.props;
+
+type Mark = { icon: string; bg: string; fg: string };
+
+const marks: Record<string, Mark> = {
+  anthropic: { icon: 'simple-icons:anthropic', bg: '#F4EAE0', fg: '#D97757' },
+  convex: { icon: 'simple-icons:convex', bg: '#FDECEB', fg: '#EE342F' },
+  django: { icon: 'simple-icons:django', bg: '#E5EFE9', fg: '#092E20' },
+  fastapi: { icon: 'simple-icons:fastapi', bg: '#E6F4F2', fg: '#009688' },
+  go: { icon: 'simple-icons:go', bg: '#E6F6FA', fg: '#00ADD8' },
+  kubernetes: { icon: 'simple-icons:kubernetes', bg: '#E8EEFB', fg: '#326CE5' },
+  mcp: { icon: 'lucide:plug', bg: '#EEF1F8', fg: '#1E3A8A' },
+  modal: { icon: 'simple-icons:modal', bg: '#EFE9F8', fg: '#7B3FE4' },
+  nextjs: { icon: 'simple-icons:nextdotjs', bg: '#1B1A17', fg: '#FFFFFF' },
+  openai: { icon: 'simple-icons:openai', bg: '#E8ECF1', fg: '#202123' },
+  react: { icon: 'simple-icons:react', bg: '#E6F8FC', fg: '#0FB7E0' },
+  stripe: { icon: 'simple-icons:stripe', bg: '#EFEEFD', fg: '#635BFF' },
+  supabase: { icon: 'simple-icons:supabase', bg: '#E7F8EF', fg: '#1F8454' },
+  tailwind: { icon: 'simple-icons:tailwindcss', bg: '#E6F6FB', fg: '#06B6D4' },
+  vercel: { icon: 'simple-icons:vercel', bg: '#1B1A17', fg: '#FFFFFF' },
+};
+
+const fallback: Mark = { icon: 'lucide:book-open', bg: '#F0EDE6', fg: '#1E3A8A' };
+const { icon, bg, fg } = marks[entryKey] ?? fallback;
+const glyph = Math.round(size * 0.55);
+---
+
+<span
+  class="inline-flex items-center justify-center rounded-md"
+  style={`width:${size}px;height:${size}px;background:${bg};color:${fg};border:1px solid var(--color-hairline)`}
+  aria-hidden="true"
+>
+  <Icon name={icon} width={glyph} height={glyph} />
+</span>

--- a/website/src/pages/catalog.astro
+++ b/website/src/pages/catalog.astro
@@ -1,12 +1,14 @@
 ---
+import { Icon } from 'astro-icon/components';
 import MarketingLayout from '~/layouts/MarketingLayout.astro';
 import CommandCard from '~/components/primitives/CommandCard.astro';
+import CatalogFilter from '~/components/catalog/CatalogFilter.svelte';
 import { catalog, allTags, catalogVersion } from '~/data/catalog';
 ---
 
 <MarketingLayout title="Catalog" description="Every docs site indexed in the Pinax catalog.">
   <section class="container-page py-16">
-    <header class="hairline mb-10 border-b pb-6">
+    <header class="hairline mb-8 border-b pb-6">
       <p
         class="mb-2 text-[11px] font-semibold tracking-[0.18em] uppercase"
         style="color: var(--color-muted)"
@@ -22,39 +24,72 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
       </p>
     </header>
 
+    <div class="mb-8">
+      <CatalogFilter client:load tags={allTags} total={catalog.length} />
+    </div>
+
     <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {
-        catalog.map((entry) => (
-          <li
-            class="hairline flex flex-col rounded-lg border p-5"
-            style="background: var(--color-panel)"
-          >
-            <p class="font-serif text-lg" style="color: var(--color-fg)">
-              {entry.displayName}
-            </p>
-            <p class="mt-1 truncate text-xs" style="color: var(--color-muted)">
-              {entry.url}
-            </p>
-            <div class="mt-3 flex flex-wrap gap-1.5">
-              {entry.tags.map((tag) => (
-                <span
-                  class="hairline rounded-full border px-2 py-0.5 text-[10px] tracking-wider uppercase"
-                  style="color: var(--color-muted)"
+        catalog.map((entry) => {
+          const search = [entry.displayName, entry.key, entry.url, ...entry.tags].join(' ');
+          return (
+            <li
+              data-catalog-card
+              data-search={search}
+              data-tags={entry.tags.join(' ')}
+              class="hairline flex flex-col rounded-lg border p-5"
+              style="background: var(--color-panel)"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <p class="font-serif text-lg leading-tight" style="color: var(--color-fg)">
+                  {entry.displayName}
+                </p>
+                <a
+                  href={entry.url}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label={`Open ${entry.displayName} docs in a new tab`}
+                  title="Open docs in a new tab"
+                  class="hairline inline-flex h-7 w-7 flex-none items-center justify-center rounded-md border transition-colors hover:border-[color:var(--color-fg)]"
+                  style="color: var(--color-muted); background: var(--color-bg)"
                 >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div class="mt-auto pt-4">
-              <CommandCard command={`pinax add ${entry.key}`} size="sm" />
-            </div>
-          </li>
-        ))
+                  <Icon name="lucide:external-link" width={14} height={14} />
+                </a>
+              </div>
+              <p class="mt-1 truncate text-xs" style="color: var(--color-muted)">
+                {entry.url}
+              </p>
+              <div class="mt-3 flex flex-wrap gap-1.5">
+                {entry.tags.map((tag) => (
+                  <span
+                    class="hairline rounded-full border px-2 py-0.5 text-[10px] tracking-wider uppercase"
+                    style="color: var(--color-muted)"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <div class="mt-auto pt-4">
+                <CommandCard command={`pinax add ${entry.key}`} size="sm" />
+              </div>
+            </li>
+          );
+        })
       }
     </ul>
 
-    <p class="mt-10 text-xs" style="color: var(--color-muted)">
-      Tags: {allTags.join(' · ')}
-    </p>
+    <div
+      data-catalog-empty
+      hidden
+      class="hairline mt-4 rounded-lg border p-10 text-center"
+      style="background: var(--color-panel); color: var(--color-muted)"
+    >
+      <p class="font-serif text-xl" style="color: var(--color-fg)">No matches.</p>
+      <p class="mt-2 text-sm">
+        Try a different search term, or clear the filters. You can also pass any URL directly: <code
+          >pinax add &lt;url&gt;</code
+        >.
+      </p>
+    </div>
   </section>
 </MarketingLayout>

--- a/website/src/pages/catalog.astro
+++ b/website/src/pages/catalog.astro
@@ -23,6 +23,15 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
         >, a dot or a slash is treated as a URL, so
         <code>pinax add &lt;url&gt;</code> still works.
       </p>
+      <div class="mt-5 max-w-md">
+        <p
+          class="mb-2 text-[11px] font-semibold tracking-[0.18em] uppercase"
+          style="color: var(--color-muted)"
+        >
+          Pull the latest list
+        </p>
+        <CommandCard command="pinax catalog refresh" size="sm" />
+      </div>
     </header>
 
     <div class="mb-8">
@@ -98,5 +107,28 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
         >.
       </p>
     </div>
+
+    <aside
+      class="hairline mt-12 flex flex-col items-start justify-between gap-4 rounded-lg border p-6 sm:flex-row sm:items-center"
+      style="background: var(--color-panel)"
+    >
+      <div>
+        <p class="font-serif text-lg" style="color: var(--color-fg)">Want a docs site added?</p>
+        <p class="mt-1 text-sm" style="color: var(--color-muted)">
+          Open a request and we'll review it for the next catalog version.
+        </p>
+      </div>
+      <a
+        href={`https://github.com/DesmondSanctity/pinax/issues/new?title=${encodeURIComponent('Catalog request: <name>')}&body=${encodeURIComponent('**Docs site name:**\n\n**Base URL:**\n\n**Why it belongs in the catalog (one line):**\n\n**Suggested tags:**\n')}&labels=catalog`}
+        target="_blank"
+        rel="noopener"
+        class="hairline inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors hover:border-[color:var(--color-fg)]"
+        style="color: var(--color-fg); background: var(--color-bg)"
+      >
+        <Icon name="simple-icons:github" width={16} height={16} />
+        Open a request
+        <Icon name="lucide:external-link" width={14} height={14} />
+      </a>
+    </aside>
   </section>
 </MarketingLayout>

--- a/website/src/pages/catalog.astro
+++ b/website/src/pages/catalog.astro
@@ -3,6 +3,7 @@ import { Icon } from 'astro-icon/components';
 import MarketingLayout from '~/layouts/MarketingLayout.astro';
 import CommandCard from '~/components/primitives/CommandCard.astro';
 import CatalogFilter from '~/components/catalog/CatalogFilter.svelte';
+import CatalogLogo from '~/components/icons/CatalogLogo.astro';
 import { catalog, allTags, catalogVersion } from '~/data/catalog';
 ---
 
@@ -41,9 +42,15 @@ import { catalog, allTags, catalogVersion } from '~/data/catalog';
               style="background: var(--color-panel)"
             >
               <div class="flex items-start justify-between gap-3">
-                <p class="font-serif text-lg leading-tight" style="color: var(--color-fg)">
-                  {entry.displayName}
-                </p>
+                <div class="flex min-w-0 items-center gap-3">
+                  <CatalogLogo entryKey={entry.key} size={32} />
+                  <p
+                    class="truncate font-serif text-lg leading-tight"
+                    style="color: var(--color-fg)"
+                  >
+                    {entry.displayName}
+                  </p>
+                </div>
                 <a
                   href={entry.url}
                   target="_blank"


### PR DESCRIPTION
This pull request introduces a new interactive filtering UI for the catalog page, significantly improving the user experience for browsing and searching catalog entries. The changes add a Svelte-based filter component, enhance catalog cards with icons and external links, and improve empty state handling.

**Catalog Filtering and UI Improvements:**

* Added a new `CatalogFilter.svelte` component that enables live searching and filtering of catalog entries by tags and keywords, with a clear button and entry count display.
* Integrated `CatalogFilter` into the catalog page, passing all tags and total count as props, and updated catalog cards to include searchable metadata via `data-*` attributes.

**Catalog Card Enhancements:**

* Introduced a new `CatalogLogo.astro` component that displays a relevant icon and color for each catalog entry, improving visual identification.
* Updated catalog cards to show the logo, make the docs link more prominent with an external link icon, and improve the layout for better usability.

**Empty State Handling:**

* Added an empty state message and UI that appears when no catalog entries match the current filters, guiding users to adjust their search or filters.

These changes collectively make the catalog page more interactive, visually appealing, and user-friendly.
