### PR TITLE
Site/phase 3

### DIFF
--- a/website/src/components/docs/Breadcrumb.astro
+++ b/website/src/components/docs/Breadcrumb.astro
@@ -6,12 +6,14 @@ type Props = {
 const { group, title } = Astro.props;
 ---
 
-<nav aria-label="Breadcrumb" class="text-xs" style="color: var(--color-muted)">
-  <ol class="flex flex-wrap items-center gap-1.5" style="list-style: none; padding-left: 0;">
-    <li><a href="/docs/quick-start" class="hover:underline">Docs</a></li>
-    <li aria-hidden>/</li>
-    <li>{group}</li>
-    <li aria-hidden>/</li>
-    <li style="color: var(--color-fg)">{title}</li>
-  </ol>
+<nav
+  aria-label="Breadcrumb"
+  class="flex flex-wrap items-center gap-1.5 text-xs"
+  style="color: var(--color-muted)"
+>
+  <a href="/docs/quick-start" class="hover:underline">Docs</a>
+  <span aria-hidden>/</span>
+  <span>{group}</span>
+  <span aria-hidden>/</span>
+  <span style="color: var(--color-fg)">{title}</span>
 </nav>

--- a/website/src/components/docs/Breadcrumb.astro
+++ b/website/src/components/docs/Breadcrumb.astro
@@ -1,0 +1,17 @@
+---
+type Props = {
+  group: string;
+  title: string;
+};
+const { group, title } = Astro.props;
+---
+
+<nav aria-label="Breadcrumb" class="text-xs" style="color: var(--color-muted)">
+  <ol class="flex flex-wrap items-center gap-1.5" style="list-style: none; padding-left: 0;">
+    <li><a href="/docs/quick-start" class="hover:underline">Docs</a></li>
+    <li aria-hidden>/</li>
+    <li>{group}</li>
+    <li aria-hidden>/</li>
+    <li style="color: var(--color-fg)">{title}</li>
+  </ol>
+</nav>

--- a/website/src/components/docs/DocsSearch.svelte
+++ b/website/src/components/docs/DocsSearch.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  type Result = {
+    url: string;
+    excerpt: string;
+    meta: { title?: string };
+  };
+
+  let { compact = false }: { compact?: boolean } = $props();
+
+  let query = $state('');
+  let results: Result[] = $state([]);
+  let open = $state(false);
+  let loading = $state(false);
+  let pagefind: { search: (q: string) => Promise<{ results: { data: () => Promise<Result> }[] }> } | null = null;
+
+  async function ensureLoaded() {
+    if (pagefind) return;
+    try {
+      const url = '/pagefind/pagefind.js';
+      const mod = await import(/* @vite-ignore */ url);
+      await mod.init?.();
+      pagefind = mod;
+    } catch {
+      pagefind = null;
+    }
+  }
+
+  async function run() {
+    const q = query.trim();
+    if (!q) {
+      results = [];
+      return;
+    }
+    loading = true;
+    await ensureLoaded();
+    if (!pagefind) {
+      loading = false;
+      return;
+    }
+    const search = await pagefind.search(q);
+    const data = await Promise.all(search.results.slice(0, 8).map((r) => r.data()));
+    results = data;
+    loading = false;
+  }
+
+  $effect(() => {
+    void query;
+    run();
+  });
+
+  onMount(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        open = true;
+        setTimeout(() => document.getElementById('pinax-docs-search-input')?.focus(), 0);
+      }
+      if (e.key === 'Escape') open = false;
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+</script>
+
+<button
+  type="button"
+  class="search-trigger"
+  class:compact
+  onclick={() => {
+    open = true;
+    setTimeout(() => document.getElementById('pinax-docs-search-input')?.focus(), 0);
+  }}
+  aria-label="Search docs"
+>
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" />
+    <path d="m20 20-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  </svg>
+  <span class="label">Search docs</span>
+  <kbd>⌘K</kbd>
+</button>
+
+{#if open}
+  <div
+    class="backdrop"
+    role="presentation"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) open = false;
+    }}
+  >
+    <div class="dialog" role="dialog" aria-modal="true" aria-label="Search docs">
+      <div class="dialog-input">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" />
+          <path d="m20 20-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+        </svg>
+        <input
+          id="pinax-docs-search-input"
+          type="search"
+          placeholder="Search the docs…"
+          bind:value={query}
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button class="esc" type="button" onclick={() => (open = false)}>Esc</button>
+      </div>
+      <div class="dialog-body">
+        {#if loading}
+          <p class="hint">Searching…</p>
+        {:else if query.trim() === ''}
+          <p class="hint">Type to search across every page.</p>
+        {:else if results.length === 0}
+          <p class="hint">No results.</p>
+        {:else}
+          <ul>
+            {#each results as r}
+              <li>
+                <a href={r.url}>
+                  <span class="title">{r.meta?.title ?? r.url}</span>
+                  <span class="excerpt">{@html r.excerpt}</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .search-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: 32px;
+    padding: 0 0.65rem;
+    border-radius: 6px;
+    background: var(--color-panel);
+    border: 1px solid var(--color-hairline);
+    color: var(--color-muted);
+    font: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: border-color 0.15s;
+  }
+  .search-trigger:hover {
+    border-color: var(--color-fg);
+  }
+  .search-trigger.compact .label {
+    display: none;
+  }
+  .label {
+    flex: 1;
+    text-align: left;
+  }
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    padding: 1px 5px;
+    border-radius: 3px;
+    border: 1px solid var(--color-hairline);
+    background: var(--color-bg);
+    color: var(--color-muted);
+  }
+
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: color-mix(in srgb, var(--color-fg) 35%, transparent);
+    z-index: 100;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 6rem 1rem 1rem;
+  }
+  .dialog {
+    width: 100%;
+    max-width: 560px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-hairline);
+    border-radius: 10px;
+    box-shadow: 0 20px 50px -10px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+  }
+  .dialog-input {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--color-hairline);
+    color: var(--color-muted);
+  }
+  .dialog-input input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    font-size: 0.95rem;
+    color: var(--color-fg);
+  }
+  .esc {
+    border: 1px solid var(--color-hairline);
+    background: var(--color-panel);
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.7rem;
+    color: var(--color-muted);
+    cursor: pointer;
+  }
+  .dialog-body {
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+  .hint {
+    padding: 1rem;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+  }
+  .dialog-body ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .dialog-body li + li {
+    border-top: 1px solid var(--color-hairline);
+  }
+  .dialog-body a {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: var(--color-fg);
+    text-decoration: none;
+  }
+  .dialog-body a:hover {
+    background: var(--color-panel);
+  }
+  .title {
+    display: block;
+    font-family: var(--font-serif);
+    font-size: 0.95rem;
+    margin-bottom: 0.2rem;
+  }
+  .excerpt {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--color-muted);
+    line-height: 1.45;
+  }
+  :global(.dialog-body mark) {
+    background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    color: inherit;
+    padding: 0 2px;
+    border-radius: 2px;
+  }
+</style>

--- a/website/src/components/docs/EditOnGitHub.astro
+++ b/website/src/components/docs/EditOnGitHub.astro
@@ -1,0 +1,20 @@
+---
+import { Icon } from 'astro-icon/components';
+import { site } from '~/lib/site';
+
+type Props = { slug: string };
+const { slug } = Astro.props;
+
+const href = `${site.repo}/edit/main/website/src/content/docs/${slug}.mdx`;
+---
+
+<a
+  href={href}
+  target="_blank"
+  rel="noopener"
+  class="inline-flex items-center gap-1.5 text-sm transition-opacity hover:opacity-70"
+  style="color: var(--color-muted)"
+>
+  <Icon name="lucide:pencil-line" width={14} height={14} />
+  Edit this page on GitHub
+</a>

--- a/website/src/components/docs/PrevNext.astro
+++ b/website/src/components/docs/PrevNext.astro
@@ -1,0 +1,62 @@
+---
+import { Icon } from 'astro-icon/components';
+import { docsOrder } from '~/data/docsNav';
+
+type Props = { slug: string };
+const { slug } = Astro.props;
+
+const idx = docsOrder.findIndex((d) => d.slug === slug);
+const prev = idx > 0 ? docsOrder[idx - 1] : null;
+const next = idx >= 0 && idx < docsOrder.length - 1 ? docsOrder[idx + 1] : null;
+---
+
+{
+  (prev || next) && (
+    <nav
+      aria-label="Pager"
+      class="mt-12 grid grid-cols-2 gap-4 border-t pt-8"
+      style="border-color: var(--color-hairline)"
+    >
+      <div>
+        {prev && (
+          <a
+            href={`/docs/${prev.slug}`}
+            class="hairline group flex flex-col gap-1 rounded-lg border p-4 transition-colors hover:border-[color:var(--color-fg)]"
+            style="background: var(--color-panel)"
+          >
+            <span
+              class="inline-flex items-center gap-1 text-[11px] tracking-wider uppercase"
+              style="color: var(--color-muted)"
+            >
+              <Icon name="lucide:arrow-left" width={12} height={12} />
+              Previous
+            </span>
+            <span class="font-serif text-base" style="color: var(--color-fg)">
+              {prev.label}
+            </span>
+          </a>
+        )}
+      </div>
+      <div class="text-right">
+        {next && (
+          <a
+            href={`/docs/${next.slug}`}
+            class="hairline group flex flex-col items-end gap-1 rounded-lg border p-4 transition-colors hover:border-[color:var(--color-fg)]"
+            style="background: var(--color-panel)"
+          >
+            <span
+              class="inline-flex items-center gap-1 text-[11px] tracking-wider uppercase"
+              style="color: var(--color-muted)"
+            >
+              Next
+              <Icon name="lucide:arrow-right" width={12} height={12} />
+            </span>
+            <span class="font-serif text-base" style="color: var(--color-fg)">
+              {next.label}
+            </span>
+          </a>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/website/src/components/docs/Sidebar.astro
+++ b/website/src/components/docs/Sidebar.astro
@@ -1,46 +1,12 @@
 ---
-type Group = {
-  label: string;
-  items: readonly { label: string; href: string }[];
-};
-
-const groups: readonly Group[] = [
-  {
-    label: 'Guides',
-    items: [
-      { label: 'Quick start', href: '/docs/quick-start' },
-      { label: 'Catalog', href: '/docs/catalog' },
-      { label: 'Serve', href: '/docs/serve' },
-      { label: 'Configuration', href: '/docs/configuration' },
-      { label: 'Troubleshooting', href: '/docs/troubleshooting' },
-    ],
-  },
-  {
-    label: 'Reference',
-    items: [
-      { label: 'CLI', href: '/docs/cli' },
-      { label: 'MCP tools', href: '/docs/mcp-tools' },
-      { label: 'Architecture', href: '/docs/architecture' },
-    ],
-  },
-  {
-    label: 'Clients',
-    items: [
-      { label: 'Claude Desktop', href: '/docs/clients/claude-desktop' },
-      { label: 'Claude Code', href: '/docs/clients/claude-code' },
-      { label: 'Cursor', href: '/docs/clients/cursor' },
-      { label: 'Windsurf', href: '/docs/clients/windsurf' },
-      { label: 'Cline', href: '/docs/clients/cline' },
-    ],
-  },
-];
+import { docsGroups } from '~/data/docsNav';
 
 const path = Astro.url.pathname;
 ---
 
 <nav aria-label="Docs navigation" class="text-sm">
   {
-    groups.map((group) => (
+    docsGroups.map((group) => (
       <div class="mb-6">
         <p
           class="mb-2 text-[11px] font-semibold tracking-[0.14em] uppercase"
@@ -50,11 +16,12 @@ const path = Astro.url.pathname;
         </p>
         <ul class="space-y-1.5">
           {group.items.map((item) => {
-            const active = path === item.href;
+            const href = `/docs/${item.slug}`;
+            const active = path === href;
             return (
               <li>
                 <a
-                  href={item.href}
+                  href={href}
                   class="block rounded px-2 py-1 transition-colors hover:bg-[color:var(--color-panel)]"
                   style={`color: ${active ? 'var(--color-primary)' : 'var(--color-fg)'}; font-weight: ${active ? '600' : '400'}`}
                 >

--- a/website/src/components/docs/Toc.astro
+++ b/website/src/components/docs/Toc.astro
@@ -1,0 +1,34 @@
+---
+import type { MarkdownHeading } from 'astro';
+
+type Props = { headings: readonly MarkdownHeading[] };
+const { headings } = Astro.props;
+
+const items = headings.filter((h) => h.depth === 2 || h.depth === 3);
+---
+
+{
+  items.length > 0 && (
+    <nav aria-label="On this page" class="text-sm">
+      <p
+        class="mb-2 text-[11px] font-semibold tracking-[0.14em] uppercase"
+        style="color: var(--color-muted)"
+      >
+        On this page
+      </p>
+      <ul class="space-y-1.5">
+        {items.map((h) => (
+          <li class={h.depth === 3 ? 'pl-3' : ''}>
+            <a
+              href={`#${h.slug}`}
+              class="block truncate transition-colors hover:text-[color:var(--color-primary)]"
+              style="color: var(--color-muted)"
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -1,0 +1,105 @@
+---
+title: Architecture
+description: How a URL becomes a manifest, and how a manifest becomes five MCP tools.
+section: reference
+order: 2
+---
+
+Pinax is a single Go binary structured as a handful of focused packages.
+Below is the pipeline a URL takes from `pinax add` to `pinax serve`,
+followed by the on-disk layout.
+
+## The pipeline
+
+```
+            ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
+URL ──────▶ │  preflight   │──▶│   crawler    │──▶│  extractor   │──▶ manifest.json
+            └──────────────┘   └──────────────┘   └──────────────┘
+              density gate      llms.txt →           HTML/MD →
+              one-shot fetch    sitemap →            clean Markdown
+                                bounded BFS
+```
+
+```
+manifest.json ──▶ BM25 index ──▶  mcp server ──▶ stdio / HTTP transport
+                                  list_docs
+                                  list_sections    ▶ in-memory
+                                  search_pages     ▶ in-memory
+                                  get_section_pages▶ in-memory
+                                  get_page         ▶ network + SQLite cache
+```
+
+## Discovery, in order
+
+The crawler tries three strategies and stops at the first that yields a
+non-empty page list:
+
+1. **`llms.txt` probe.** Fetches `/llms.txt` at the host root. If present,
+   every URL it lists becomes a manifest entry — no BFS at all.
+2. **Sitemap parse.** Walks every URL declared in `/sitemap.xml` (and any
+   referenced sitemap indexes), filtered by the host.
+3. **Bounded BFS.** Starts at the homepage, follows in-host links breadth-
+   first up to `--max-pages` (default 1500), respects `--exclude` filters,
+   bails on JS-heavy pages.
+
+All three strategies feed the same downstream pipeline. The crawler
+records which strategy fired in the manifest so `pinax doctor` can warn
+when a BFS-derived manifest has thin pages.
+
+## Extraction
+
+The extractor accepts whatever the discovery step found:
+
+- `text/markdown` responses pass through with a light cleanup.
+- HTML is parsed, navigation/footer/cookie chrome is stripped, then
+  converted to Markdown.
+- The first `<h1>` becomes the page title; sections are derived from URL
+  path segments, not headings.
+
+## Manifest
+
+`~/.pinax/servers/<name>/manifest.json` is the source of truth. It
+contains:
+
+- Base URL, display name, discovery strategy used, last-refresh timestamp.
+- One entry per page: URL, title, section path, prose-length estimate.
+- The tag set (when added through the catalog).
+
+It's written atomically — Pinax writes to a temp file in the same
+directory then renames into place, so a half-completed `pinax add` never
+corrupts the on-disk state.
+
+## Search
+
+A small BM25 index over URL paths, titles, and section names is built
+alongside each manifest. The actual page bodies are _not_ indexed —
+search hits return URLs which `get_page` fetches live. This is by design:
+it keeps the on-disk footprint tiny and the live-fetch policy honest.
+
+## Serve
+
+`pinax serve` mounts every manifest from `~/.pinax/servers/` into a single
+MCP server with five tools. The unified mode lets one configured server
+cover every docs site you've added; the optional `docs` argument scopes
+calls when an agent wants to narrow.
+
+Transport is `mark3labs/mcp-go`: stdio is the default, Streamable HTTP +
+SSE are available with `--http`.
+
+## Package map
+
+```
+cmd/pinax/         CLI entry point and argument parser
+internal/buildinfo/ Version + User-Agent shared across CLI and server
+internal/crawler/   llms.txt probe, sitemap parser, BFS, platform detection
+internal/extractor/ HTML/Markdown → clean Markdown
+internal/manifest/  Atomic JSON manifests + BM25 indexes
+internal/cache/     SQLite page cache (WAL, TTL applied at read time)
+internal/logger/    SQLite tool-call log + HTML log viewer
+internal/mcp/       MCP server, transport, tools, middleware
+internal/preflight/ Content-density check that gates `pinax add`
+internal/doctor/    Health diagnosis used by `pinax doctor`
+internal/catalog/   Built-in catalog + cache loader
+```
+
+Each package has its own README in the source tree.

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -89,17 +89,17 @@ SSE are available with `--http`.
 ## Package map
 
 ```
-cmd/pinax/         CLI entry point and argument parser
-internal/buildinfo/ Version + User-Agent shared across CLI and server
-internal/crawler/   llms.txt probe, sitemap parser, BFS, platform detection
-internal/extractor/ HTML/Markdown → clean Markdown
-internal/manifest/  Atomic JSON manifests + BM25 indexes
-internal/cache/     SQLite page cache (WAL, TTL applied at read time)
-internal/logger/    SQLite tool-call log + HTML log viewer
-internal/mcp/       MCP server, transport, tools, middleware
-internal/preflight/ Content-density check that gates `pinax add`
-internal/doctor/    Health diagnosis used by `pinax doctor`
-internal/catalog/   Built-in catalog + cache loader
+cmd/pinax/            CLI entry point and argument parser
+internal/buildinfo/   Version + User-Agent shared across CLI and server
+internal/crawler/     llms.txt probe, sitemap parser, BFS, platform detection
+internal/extractor/   HTML/Markdown → clean Markdown
+internal/manifest/    Atomic JSON manifests + BM25 indexes
+internal/cache/       SQLite page cache (WAL, TTL applied at read time)
+internal/logger/      SQLite tool-call log + HTML log viewer
+internal/mcp/         MCP server, transport, tools, middleware
+internal/preflight/   Content-density check that gates `pinax add`
+internal/doctor/      Health diagnosis used by `pinax doctor`
+internal/catalog/     Built-in catalog + cache loader
 ```
 
 Each package has its own README in the source tree.

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -50,13 +50,29 @@ only `get_page` reaches the network.
 ### Tool call: `get_page` lifecycle
 
 ```
-agent ─▶ get_page(url)
-           │
-           ├─ cache hit  ────────────────────────────▶ clean Markdown
-           │
-           └─ cache miss ─▶ HTTP fetch ─▶ extractor ─▶ cache.Set ─▶ clean Markdown
-                                          HTML/MD →
-                                          clean Markdown
+       agent
+         │
+         ▼
+     get_page(url)
+         │
+         ▼
+    ┌─────────┐    hit
+    │  cache  │ ─────────────▶ clean Markdown
+    └─────────┘
+         │ miss
+         ▼
+     HTTP fetch
+         │
+         ▼
+      extractor
+   (HTML/MD →
+    clean Markdown)
+         │
+         ▼
+      cache.Set
+         │
+         ▼
+    clean Markdown
 ```
 
 Cached pages return immediately. On a miss, Pinax fetches the URL with

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -11,23 +11,58 @@ followed by the on-disk layout.
 
 ## The pipeline
 
-```
-            ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
-URL ──────▶ │  preflight   │──▶│   crawler    │──▶│  extractor   │──▶ manifest.json
-            └──────────────┘   └──────────────┘   └──────────────┘
-              density gate      llms.txt →           HTML/MD →
-              one-shot fetch    sitemap →            clean Markdown
-                                bounded BFS
-```
+A URL becomes a manifest, and a manifest becomes a set of tools. Pinax
+keeps the two halves loosely coupled — the on-disk manifest is the only
+contract between them — so each can change independently.
+
+### Add: URL → manifest
 
 ```
-manifest.json ──▶ BM25 index ──▶  mcp server ──▶ stdio / HTTP transport
-                                  list_docs
-                                  list_sections    ▶ in-memory
-                                  search_pages     ▶ in-memory
-                                  get_section_pages▶ in-memory
-                                  get_page         ▶ network + SQLite cache
+            ┌──────────────┐    ┌──────────────┐
+URL ──────▶ │   crawler    │──▶ │  preflight   │──▶ manifest.json
+            └──────────────┘    └──────────────┘
+              llms.txt →          density gate
+              sitemap →           (samples, extracts,
+              bounded BFS          refuses if thin)
 ```
+
+`pinax add` runs discovery then a gate. The crawler tries `llms.txt`,
+then `sitemap.xml`, then bounded BFS, and stops at the first strategy
+that yields pages. The preflight gate then samples that page set,
+extracts each sample to measure prose density, and refuses to write the
+manifest when the site is mostly chrome.
+
+### Serve: manifest → MCP tools
+
+```
+manifest.json ──▶ BM25 index ──▶ mcp server ──▶ stdio / HTTP transport
+                                  list_docs
+                                  list_sections
+                                  search_pages
+                                  get_section_pages
+                                  get_page
+```
+
+`pinax serve` mounts every manifest under `~/.pinax/servers/` into a
+single MCP server. Four of the five tools serve from in-memory state;
+only `get_page` reaches the network.
+
+### Tool call: `get_page` lifecycle
+
+```
+agent ─▶ get_page(url)
+           │
+           ├─ cache hit  ────────────────────────────▶ clean Markdown
+           │
+           └─ cache miss ─▶ HTTP fetch ─▶ extractor ─▶ cache.Set ─▶ clean Markdown
+                                          HTML/MD →
+                                          clean Markdown
+```
+
+Cached pages return immediately. On a miss, Pinax fetches the URL with
+the configured `User-Agent`, runs the extractor to strip nav/footer
+chrome and normalise HTML to Markdown, and stores the result in the
+SQLite cache (WAL mode, TTL applied at read time) before returning it.
 
 ## Discovery, in order
 
@@ -48,13 +83,18 @@ when a BFS-derived manifest has thin pages.
 
 ## Extraction
 
-The extractor accepts whatever the discovery step found:
+The extractor turns whatever Pinax fetched into clean Markdown. It runs
+in two places: inside preflight during sampling, and inside `get_page`
+on every live fetch.
 
 - `text/markdown` responses pass through with a light cleanup.
 - HTML is parsed, navigation/footer/cookie chrome is stripped, then
   converted to Markdown.
-- The first `<h1>` becomes the page title; sections are derived from URL
-  path segments, not headings.
+
+Page titles are not produced by the extractor — they come from the
+crawler, which reads the HTML `<title>` element and falls back to a
+URL-slug title when none is present (e.g. sitemap-only sites). Sections
+are derived from URL path segments, not headings.
 
 ## Manifest
 
@@ -62,7 +102,7 @@ The extractor accepts whatever the discovery step found:
 contains:
 
 - Base URL, display name, discovery strategy used, last-refresh timestamp.
-- One entry per page: URL, title, section path, prose-length estimate.
+- One entry per page: URL, title, and section path.
 - The tag set (when added through the catalog).
 
 It's written atomically — Pinax writes to a temp file in the same
@@ -78,13 +118,10 @@ it keeps the on-disk footprint tiny and the live-fetch policy honest.
 
 ## Serve
 
-`pinax serve` mounts every manifest from `~/.pinax/servers/` into a single
-MCP server with five tools. The unified mode lets one configured server
-cover every docs site you've added; the optional `docs` argument scopes
-calls when an agent wants to narrow.
-
-Transport is `mark3labs/mcp-go`: stdio is the default, Streamable HTTP +
-SSE are available with `--http`.
+The unified server lets one MCP configuration cover every docs site
+you've added; the optional `docs` argument scopes calls when an agent
+wants to narrow. Transport is `mark3labs/mcp-go`: stdio is the default,
+Streamable HTTP + SSE are available with `--http`.
 
 ## Package map
 

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -12,8 +12,8 @@ followed by the on-disk layout.
 ## The pipeline
 
 A URL becomes a manifest, and a manifest becomes a set of tools. Pinax
-keeps the two halves loosely coupled — the on-disk manifest is the only
-contract between them — so each can change independently.
+keeps the two halves loosely coupled - the on-disk manifest is the only
+contract between them - so each can change independently.
 
 ### Add: URL → manifest
 
@@ -70,7 +70,7 @@ The crawler tries three strategies and stops at the first that yields a
 non-empty page list:
 
 1. **`llms.txt` probe.** Fetches `/llms.txt` at the host root. If present,
-   every URL it lists becomes a manifest entry — no BFS at all.
+   every URL it lists becomes a manifest entry - no BFS at all.
 2. **Sitemap parse.** Walks every URL declared in `/sitemap.xml` (and any
    referenced sitemap indexes), filtered by the host.
 3. **Bounded BFS.** Starts at the homepage, follows in-host links breadth-
@@ -91,7 +91,7 @@ on every live fetch.
 - HTML is parsed, navigation/footer/cookie chrome is stripped, then
   converted to Markdown.
 
-Page titles are not produced by the extractor — they come from the
+Page titles are not produced by the extractor - they come from the
 crawler, which reads the HTML `<title>` element and falls back to a
 URL-slug title when none is present (e.g. sitemap-only sites). Sections
 are derived from URL path segments, not headings.
@@ -105,14 +105,14 @@ contains:
 - One entry per page: URL, title, and section path.
 - The tag set (when added through the catalog).
 
-It's written atomically — Pinax writes to a temp file in the same
+It's written atomically - Pinax writes to a temp file in the same
 directory then renames into place, so a half-completed `pinax add` never
 corrupts the on-disk state.
 
 ## Search
 
 A small BM25 index over URL paths, titles, and section names is built
-alongside each manifest. The actual page bodies are _not_ indexed —
+alongside each manifest. The actual page bodies are _not_ indexed -
 search hits return URLs which `get_page` fetches live. This is by design:
 it keeps the on-disk footprint tiny and the live-fetch policy honest.
 

--- a/website/src/content/docs/catalog.mdx
+++ b/website/src/content/docs/catalog.mdx
@@ -6,7 +6,7 @@ order: 1
 ---
 
 `pinax add <name>` resolves through a small built-in catalog. Today that's
-15 entries — Stripe, React, Next.js, Convex, Anthropic, OpenAI, Supabase,
+15 entries - Stripe, React, Next.js, Convex, Anthropic, OpenAI, Supabase,
 Tailwind, FastAPI, Django, Go stdlib, Kubernetes, Vercel, Modal, MCP. The
 full list with tags lives at [/catalog](/catalog).
 
@@ -24,7 +24,7 @@ pinax add stripe                          # same end result
 pinax catalog list
 ```
 
-Prints the catalog the CLI is currently using — name, base URL, tags, one
+Prints the catalog the CLI is currently using - name, base URL, tags, one
 per line. Use it when you forget the exact slug.
 
 ## Refreshing

--- a/website/src/content/docs/catalog.mdx
+++ b/website/src/content/docs/catalog.mdx
@@ -1,0 +1,77 @@
+---
+title: Catalog
+description: The curated list of docs sites Pinax knows by name, plus how to refresh and override it.
+section: guides
+order: 1
+---
+
+`pinax add <name>` resolves through a small built-in catalog. Today that's
+15 entries — Stripe, React, Next.js, Convex, Anthropic, OpenAI, Supabase,
+Tailwind, FastAPI, Django, Go stdlib, Kubernetes, Vercel, Modal, MCP. The
+full list with tags lives at [/catalog](/catalog).
+
+Anything containing `://`, a `.`, or a `/` is still treated as a URL, so
+your existing scripts keep working:
+
+```sh
+pinax add https://docs.convex.dev
+pinax add stripe                          # same end result
+```
+
+## Listing entries
+
+```sh
+pinax catalog list
+```
+
+Prints the catalog the CLI is currently using — name, base URL, tags, one
+per line. Use it when you forget the exact slug.
+
+## Refreshing
+
+The CLI ships with a built-in copy compiled in. To pull the latest version
+from GitHub:
+
+```sh
+pinax catalog refresh
+```
+
+This fetches `internal/catalog/catalog.json` from `main` and caches it under
+`~/.pinax/catalog.json`. From then on `pinax add <name>` consults the cache
+first, then falls back to the compiled-in copy.
+
+## Custom or forked catalogs
+
+Point `refresh` at a different URL with `PINAX_CATALOG_URL`:
+
+```sh
+PINAX_CATALOG_URL=https://intra.example.com/pinax-catalog.json \
+  pinax catalog refresh
+```
+
+Useful for private docs hubs at work, or for testing a catalog change in a
+fork before opening a PR.
+
+## Shape of a catalog entry
+
+```jsonc
+{
+  "version": "2026.06.25",
+  "entries": {
+    "stripe": {
+      "displayName": "Stripe",
+      "url": "https://docs.stripe.com",
+      "tags": ["payments", "backend"],
+    },
+  },
+}
+```
+
+Optional fields: `llmsTxt` to pin a specific manifest URL, `platform` to
+declare a known doc engine (Mintlify, Docusaurus…), `excludes` to filter
+out path prefixes during crawl.
+
+## Want a docs site added?
+
+[Open a request on GitHub](https://github.com/desmondsanctity/pinax/issues/new?title=Catalog%20request%3A%20%3Cname%3E&labels=catalog).
+We review them per release and ship updates alongside the binary.

--- a/website/src/content/docs/cli.mdx
+++ b/website/src/content/docs/cli.mdx
@@ -1,0 +1,118 @@
+---
+title: CLI
+description: Every Pinax command, every flag, with a real example for each.
+section: reference
+order: 0
+---
+
+Run `pinax --help` for an interactive version of this page. Everything
+below is captured from the same help text the binary ships with.
+
+## `pinax add`
+
+Index a new docs site by name (from the catalog) or by URL.
+
+```sh
+pinax add <url|catalog-name> \
+  [--name NAME] \
+  [--exclude PATTERN ...] \
+  [--max-pages N] \
+  [--no-preflight]
+```
+
+| Flag             | Default | Notes                                                                        |
+| ---------------- | ------- | ---------------------------------------------------------------------------- |
+| `--name`         | derived | server name; defaults to the host or catalog key                             |
+| `--exclude`      | none    | repeatable substring filter applied to discovered URLs                       |
+| `--max-pages`    | `1500`  | crawl ceiling; reached pages stop discovery early                            |
+| `--no-preflight` | off     | skip the content density gate (see [Troubleshooting](/docs/troubleshooting)) |
+
+## `pinax list`
+
+```sh
+pinax list
+```
+
+Tabulates every manifest under `~/.pinax/servers/` with page count, base
+URL, and last refresh time.
+
+## `pinax remove`
+
+```sh
+pinax remove <name>
+```
+
+Deletes a manifest plus its BM25 index. Leaves the page cache alone —
+clear that separately with `pinax cache clear`.
+
+## `pinax refresh`
+
+```sh
+pinax refresh <name> [--rebuild-index]
+```
+
+Re-runs discovery against the recorded base URL and writes a fresh
+manifest. `--rebuild-index` forces the BM25 index to be regenerated even
+if the page list hasn't changed (useful after a Pinax upgrade).
+
+## `pinax search`
+
+Out-of-band search, mostly for debugging:
+
+```sh
+pinax search stripe "payment intent"
+```
+
+Hits the same code path as the `search_pages` MCP tool, but prints to
+stdout instead of returning JSON.
+
+## `pinax doctor`
+
+```sh
+pinax doctor [<name>...] [--json]
+```
+
+Reports drift, thin pages, and broken section anchors for one, several,
+or all manifests. Output is human-readable by default; `--json` is meant
+for scripting.
+
+## `pinax serve`
+
+```sh
+pinax serve [<name>] [--http] [--port N] [--host HOST]
+```
+
+Runs the MCP server. See [Serve](/docs/serve) for the full transport
+discussion.
+
+## `pinax cache`
+
+```sh
+pinax cache clear [--older-than DURATION]
+```
+
+Wipes the SQLite page cache. `--older-than 24h` only evicts entries last
+fetched more than 24 hours ago.
+
+## `pinax catalog`
+
+```sh
+pinax catalog list      # show every catalog entry
+pinax catalog refresh   # fetch the latest catalog.json
+```
+
+`refresh` respects `PINAX_CATALOG_URL`. See [Catalog](/docs/catalog).
+
+## `pinax config claude`
+
+Print a ready-to-paste Claude config snippet:
+
+```sh
+pinax config claude [--project] [--split] [--force]
+```
+
+| Flag        | What it does                                                                        |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `--project` | scope the snippet to the current project's `.mcp.json` instead of the global config |
+| `--split`   | write one entry per manifest instead of a single unified server                     |
+| `--force`   | overwrite an existing entry of the same name                                        |

--- a/website/src/content/docs/cli.mdx
+++ b/website/src/content/docs/cli.mdx
@@ -42,7 +42,7 @@ URL, and last refresh time.
 pinax remove <name>
 ```
 
-Deletes a manifest plus its BM25 index. Leaves the page cache alone —
+Deletes a manifest plus its BM25 index. Leaves the page cache alone -
 clear that separately with `pinax cache clear`.
 
 ## `pinax refresh`

--- a/website/src/content/docs/clients/claude-code.mdx
+++ b/website/src/content/docs/clients/claude-code.mdx
@@ -1,0 +1,66 @@
+---
+title: Claude Code
+description: Register Pinax as an MCP server for Anthropic's terminal coding agent.
+section: clients
+order: 1
+---
+
+Claude Code registers MCP servers from the CLI — no config file editing.
+
+## 1. Index a docs site
+
+```sh
+pinax add stripe
+```
+
+## 2. Register the server
+
+```sh
+claude mcp add pinax -- pinax serve
+```
+
+A single registration covers every manifest. To register one per docs
+site:
+
+```sh
+claude mcp add stripe-docs -- pinax serve stripe
+```
+
+`claude mcp add` writes to `~/.claude/.mcp.json` (or the project-local
+`.mcp.json` if you pass `--project`).
+
+## 3. Confirm it's loaded
+
+```sh
+claude mcp list
+```
+
+Should print your new entry with its command and args.
+
+## 4. Use it
+
+Inside a Claude Code session:
+
+> /tools
+
+You'll see `pinax__list_docs`, `pinax__search_pages`, and the rest. Ask
+the agent to call them by name when you want it to consult the docs.
+
+## Per-project setup
+
+If you want a project to ship with a specific Pinax server (so a
+teammate's `claude` CLI auto-registers it):
+
+```sh
+cd my-project
+pinax config claude --project
+```
+
+That writes `.mcp.json` in the current directory. Commit it.
+
+## Troubleshooting
+
+- `claude mcp add` writes the entry as-typed; if `pinax` isn't on Claude
+  Code's PATH, edit `.mcp.json` and replace `pinax` with the absolute
+  path.
+- `claude mcp remove pinax` undoes the registration cleanly.

--- a/website/src/content/docs/clients/claude-code.mdx
+++ b/website/src/content/docs/clients/claude-code.mdx
@@ -5,7 +5,7 @@ section: clients
 order: 1
 ---
 
-Claude Code registers MCP servers from the CLI — no config file editing.
+Claude Code registers MCP servers from the CLI - no config file editing.
 
 ## 1. Index a docs site
 

--- a/website/src/content/docs/clients/claude-desktop.mdx
+++ b/website/src/content/docs/clients/claude-desktop.mdx
@@ -55,7 +55,7 @@ pinax config claude --split    # one entry per manifest
 
 ## 3. Restart Claude Desktop
 
-Quit and relaunch — the app only reads the config file at startup. You
+Quit and relaunch - the app only reads the config file at startup. You
 should see a small plug icon in the conversation header confirming the
 server is connected.
 
@@ -74,7 +74,7 @@ from the live page.
 - **"Failed to load tools"** in the Claude UI usually means `pinax` isn't
   on the PATH the desktop app inherits. Use an absolute path in `command`
   (the output of `which pinax`).
-- **No tools listed at all** — quit Claude Desktop fully (Cmd-Q on macOS,
+- **No tools listed at all** - quit Claude Desktop fully (Cmd-Q on macOS,
   not just close the window) and relaunch.
 - For deeper debugging, run `pinax serve --http` in a terminal and watch
   the log UI at `http://localhost:8423/` while Claude makes calls.

--- a/website/src/content/docs/clients/claude-desktop.mdx
+++ b/website/src/content/docs/clients/claude-desktop.mdx
@@ -1,0 +1,80 @@
+---
+title: Claude Desktop
+description: Wire Pinax into Anthropic's official Claude Desktop client.
+section: clients
+order: 0
+---
+
+Claude Desktop reads MCP servers from a JSON config file. On macOS:
+
+```
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+On Windows: `%APPDATA%\Claude\claude_desktop_config.json`.
+
+## 1. Index a docs site
+
+```sh
+pinax add stripe
+```
+
+## 2. Add the server entry
+
+```jsonc
+{
+  "mcpServers": {
+    "pinax": {
+      "command": "pinax",
+      "args": ["serve"],
+    },
+  },
+}
+```
+
+A single `pinax serve` covers every manifest you've added. To pin a single
+docs site:
+
+```jsonc
+{
+  "mcpServers": {
+    "stripe-docs": {
+      "command": "pinax",
+      "args": ["serve", "stripe"],
+    },
+  },
+}
+```
+
+Or let Pinax write the snippet for you:
+
+```sh
+pinax config claude            # prints the unified snippet
+pinax config claude --split    # one entry per manifest
+```
+
+## 3. Restart Claude Desktop
+
+Quit and relaunch — the app only reads the config file at startup. You
+should see a small plug icon in the conversation header confirming the
+server is connected.
+
+## 4. Try it
+
+Ask Claude something only the docs would know:
+
+> Using the pinax tools, find the Stripe API method for confirming a
+> PaymentIntent and quote its required parameters.
+
+Claude will call `list_sections` → `search_pages` → `get_page` and answer
+from the live page.
+
+## Troubleshooting
+
+- **"Failed to load tools"** in the Claude UI usually means `pinax` isn't
+  on the PATH the desktop app inherits. Use an absolute path in `command`
+  (the output of `which pinax`).
+- **No tools listed at all** — quit Claude Desktop fully (Cmd-Q on macOS,
+  not just close the window) and relaunch.
+- For deeper debugging, run `pinax serve --http` in a terminal and watch
+  the log UI at `http://localhost:8423/` while Claude makes calls.

--- a/website/src/content/docs/clients/cline.mdx
+++ b/website/src/content/docs/clients/cline.mdx
@@ -1,0 +1,55 @@
+---
+title: Cline
+description: Configure Pinax for Cline, the open-source coding agent inside VS Code.
+section: clients
+order: 4
+---
+
+Cline ships with its own MCP config file. Open the Cline panel, click the
+settings cog, and select "Edit MCP settings" — or open the file directly:
+
+```
+<VS Code user dir>/cline_mcp_settings.json
+```
+
+(Exact path depends on your VS Code install; the panel's deep-link is the
+easiest route.)
+
+## 1. Index a docs site
+
+```sh
+pinax add stripe
+```
+
+## 2. Add the server entry
+
+```jsonc
+{
+  "mcpServers": {
+    "pinax": {
+      "command": "pinax",
+      "args": ["serve"],
+    },
+  },
+}
+```
+
+Pin a single docs site with `"args": ["serve", "stripe"]`.
+
+## 3. Reload Cline
+
+Click the refresh icon in the Cline MCP servers list, or reload the VS
+Code window.
+
+## 4. Use it
+
+In a Cline conversation, the new Pinax tools surface under the MCP
+section. Cline tends to be more explicit than Claude/Cursor about which
+tool it's about to call — useful while iterating on a new docs site.
+
+## Troubleshooting
+
+- Cline runs inside the VS Code extension host; if `pinax` isn't on that
+  process's PATH, use the absolute path from `which pinax`.
+- The Cline MCP panel surfaces server stdout/stderr — start there before
+  reaching for `pinax serve --http`.

--- a/website/src/content/docs/clients/cline.mdx
+++ b/website/src/content/docs/clients/cline.mdx
@@ -6,7 +6,7 @@ order: 4
 ---
 
 Cline ships with its own MCP config file. Open the Cline panel, click the
-settings cog, and select "Edit MCP settings" — or open the file directly:
+settings cog, and select "Edit MCP settings" - or open the file directly:
 
 ```
 <VS Code user dir>/cline_mcp_settings.json
@@ -45,11 +45,11 @@ Code window.
 
 In a Cline conversation, the new Pinax tools surface under the MCP
 section. Cline tends to be more explicit than Claude/Cursor about which
-tool it's about to call — useful while iterating on a new docs site.
+tool it's about to call - useful while iterating on a new docs site.
 
 ## Troubleshooting
 
 - Cline runs inside the VS Code extension host; if `pinax` isn't on that
   process's PATH, use the absolute path from `which pinax`.
-- The Cline MCP panel surfaces server stdout/stderr — start there before
+- The Cline MCP panel surfaces server stdout/stderr - start there before
   reaching for `pinax serve --http`.

--- a/website/src/content/docs/clients/cursor.mdx
+++ b/website/src/content/docs/clients/cursor.mdx
@@ -1,0 +1,62 @@
+---
+title: Cursor
+description: Hook Pinax into Cursor's MCP support, globally or per-project.
+section: clients
+order: 2
+---
+
+Cursor reads MCP servers from one of two JSON files:
+
+- Global: `~/.cursor/mcp.json`
+- Project: `.cursor/mcp.json` at the repo root
+
+## 1. Index a docs site
+
+```sh
+pinax add stripe
+```
+
+## 2. Add the server entry
+
+```jsonc
+{
+  "mcpServers": {
+    "pinax": {
+      "command": "pinax",
+      "args": ["serve"],
+    },
+  },
+}
+```
+
+A single entry covers every manifest you've added; pin a single docs site
+by adding its name to `args`:
+
+```jsonc
+{
+  "mcpServers": {
+    "stripe-docs": {
+      "command": "pinax",
+      "args": ["serve", "stripe"],
+    },
+  },
+}
+```
+
+## 3. Reload Cursor
+
+Cmd-Shift-P → "Reload Window". Cursor picks up the new servers without a
+full quit.
+
+## 4. Use it
+
+Open the chat sidebar, type `@`, and you should see the Pinax tools
+auto-completed. Or just ask Cursor to "use the pinax search tool to find
+the Stripe API for confirming a PaymentIntent" — it'll pick the right one.
+
+## Tips
+
+- Cursor's per-project config wins over the global one, so a repo can
+  ship a curated docs set for its contributors.
+- If a tool call hangs, `pinax serve --http` in a terminal lets you watch
+  the request live in the log UI at `http://localhost:8423/`.

--- a/website/src/content/docs/clients/cursor.mdx
+++ b/website/src/content/docs/clients/cursor.mdx
@@ -52,7 +52,7 @@ full quit.
 
 Open the chat sidebar, type `@`, and you should see the Pinax tools
 auto-completed. Or just ask Cursor to "use the pinax search tool to find
-the Stripe API for confirming a PaymentIntent" — it'll pick the right one.
+the Stripe API for confirming a PaymentIntent" - it'll pick the right one.
 
 ## Tips
 

--- a/website/src/content/docs/clients/windsurf.mdx
+++ b/website/src/content/docs/clients/windsurf.mdx
@@ -1,0 +1,50 @@
+---
+title: Windsurf
+description: Connect Pinax to Codeium's Windsurf editor.
+section: clients
+order: 3
+---
+
+Windsurf reads MCP servers from:
+
+```
+~/.codeium/windsurf/mcp_config.json
+```
+
+## 1. Index a docs site
+
+```sh
+pinax add stripe
+```
+
+## 2. Add the server entry
+
+```jsonc
+{
+  "mcpServers": {
+    "pinax": {
+      "command": "pinax",
+      "args": ["serve"],
+    },
+  },
+}
+```
+
+The unified entry covers every manifest. Per-docs entries work too — just
+add the catalog name as the second arg.
+
+## 3. Reload Windsurf
+
+Cmd-Shift-P → "Reload Window".
+
+## 4. Use it
+
+Open the Cascade panel. Pinax tools appear under the MCP section once the
+server connects.
+
+## Troubleshooting
+
+- Windsurf's MCP support is still evolving; if the entry doesn't take,
+  double-check `mcp_config.json` is valid JSON (no trailing commas).
+- Run `pinax serve --http` in a terminal alongside Windsurf to watch tool
+  calls in real time.

--- a/website/src/content/docs/clients/windsurf.mdx
+++ b/website/src/content/docs/clients/windsurf.mdx
@@ -30,7 +30,7 @@ pinax add stripe
 }
 ```
 
-The unified entry covers every manifest. Per-docs entries work too — just
+The unified entry covers every manifest. Per-docs entries work too - just
 add the catalog name as the second arg.
 
 ## 3. Reload Windsurf

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -21,7 +21,7 @@ environment variables for the few things that need to vary per machine.
         └── index.bin     # BM25 index for search_pages
 ```
 
-- Manifests are written atomically — a half-completed `pinax add` never
+- Manifests are written atomically - a half-completed `pinax add` never
   corrupts the on-disk state.
 - The page cache is read with TTLs applied at read time, so you can hand-
   edit `cache.db` if you want to invalidate everything (`pinax cache clear`

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -1,0 +1,68 @@
+---
+title: Configuration
+description: Where Pinax stores manifests, caches, logs, and how to override defaults via environment variables.
+section: guides
+order: 3
+---
+
+Pinax keeps everything under a single directory in `$HOME` and leans on
+environment variables for the few things that need to vary per machine.
+
+## `~/.pinax/` layout
+
+```
+~/.pinax/
+├── catalog.json          # cached catalog (after `pinax catalog refresh`)
+├── cache.db              # SQLite page cache (WAL mode)
+├── logs.db               # SQLite tool-call log used by the HTTP log UI
+└── servers/
+    └── <name>/
+        ├── manifest.json # atomic write: sections, page list, tags
+        └── index.bin     # BM25 index for search_pages
+```
+
+- Manifests are written atomically — a half-completed `pinax add` never
+  corrupts the on-disk state.
+- The page cache is read with TTLs applied at read time, so you can hand-
+  edit `cache.db` if you want to invalidate everything (`pinax cache clear`
+  is the supported route).
+
+## Environment variables
+
+| Variable            | Default                      | What it does                                       |
+| ------------------- | ---------------------------- | -------------------------------------------------- |
+| `PINAX_HOME`        | `$HOME/.pinax`               | root directory for everything Pinax stores         |
+| `PINAX_CATALOG_URL` | GitHub `main`'s catalog.json | where `pinax catalog refresh` fetches from         |
+| `PINAX_USER_AGENT`  | `pinax/<version>`            | overrides the User-Agent on outbound HTTP requests |
+| `PINAX_CACHE_TTL`   | `24h`                        | TTL applied to entries in the page cache           |
+| `PINAX_LOG_LEVEL`   | `info`                       | one of `debug`, `info`, `warn`, `error`            |
+
+All values can also be set per-invocation with the usual shell prefix:
+
+```sh
+PINAX_LOG_LEVEL=debug pinax serve --http
+```
+
+## Cache control
+
+```sh
+pinax cache clear                  # wipes the page cache
+pinax cache clear --older-than 7d  # only entries last fetched > 7d ago
+```
+
+The cache is safe to delete by hand; Pinax will rebuild it on the next
+`get_page` call.
+
+## Tuning a crawl
+
+When `pinax add <url>` is too aggressive or too thin for your docs site:
+
+```sh
+pinax add <url> --max-pages 800            # raise the crawl ceiling
+pinax add <url> --exclude '/blog/' --exclude '/legal/'   # skip prefixes
+pinax add <url> --no-preflight             # bypass the density gate
+```
+
+`--no-preflight` is the escape hatch for sites that fail the content
+density check but you want indexed anyway. The check is documented in
+[Troubleshooting](/docs/troubleshooting).

--- a/website/src/content/docs/contributing.mdx
+++ b/website/src/content/docs/contributing.mdx
@@ -1,0 +1,78 @@
+---
+title: Contributing
+description: Build, test, lint, and PR checklist for working on Pinax itself.
+section: reference
+order: 3
+---
+
+Pinax is MIT-licensed Go. Pull requests are welcome — the full contributor
+policy lives in [`CONTRIBUTING.md`](https://github.com/desmondsanctity/pinax/blob/main/CONTRIBUTING.md)
+and the code of conduct in [`CODE_OF_CONDUCT.md`](https://github.com/desmondsanctity/pinax/blob/main/CODE_OF_CONDUCT.md).
+This page is the short version.
+
+## Prerequisites
+
+- Go 1.25 or newer.
+- `golangci-lint` (for `make lint`).
+- `govulncheck` (for `make vulncheck`).
+
+Optional: Node 22 + pnpm 9 if you want to work on the [website](https://pinax.dev).
+
+## Building
+
+```sh
+git clone https://github.com/desmondsanctity/pinax.git
+cd pinax
+make build
+# binary lands at ./bin/pinax
+```
+
+Put `./bin/pinax` first on your `$PATH` while iterating, or symlink it into
+`/usr/local/bin/` once.
+
+## Test, lint, vet
+
+```sh
+make test            # go test -race ./...
+make lint            # golangci-lint
+make vulncheck       # govulncheck
+make vet             # go vet ./...
+make fmt             # gofmt -s -w .
+```
+
+Network-touching integration tests are tagged and only run when you ask:
+
+```sh
+make test-integration
+```
+
+CI runs the full matrix on every PR.
+
+## PR checklist
+
+Before you open a pull request:
+
+- [ ] `make test`, `make lint`, `make vet` all green.
+- [ ] New behaviour covered by a unit test (table-driven if it makes
+      sense). Network-touching paths get an `_integration_test.go` file.
+- [ ] Public-API changes are reflected in `README.md` _and_ in the matching
+      page under `website/src/content/docs/`.
+- [ ] Conventional Commits in the PR title (`feat:`, `fix:`, `chore:`,
+      `docs:`, `test:`, `refactor:`).
+- [ ] If you changed the catalog, run `pinax catalog list` locally to
+      sanity-check the JSON.
+
+## Reporting bugs
+
+Open an issue with:
+
+1. The exact command you ran.
+2. The full output (paste it as a fenced code block; redact tokens if
+   any).
+3. Your OS / arch and `pinax --version`.
+
+## Security
+
+Don't open a public issue for vulnerabilities. Use [GitHub Security
+Advisories](https://github.com/desmondsanctity/pinax/security/advisories/new) — see [`SECURITY.md`](https://github.com/desmondsanctity/pinax/blob/main/SECURITY.md)
+for the full policy.

--- a/website/src/content/docs/contributing.mdx
+++ b/website/src/content/docs/contributing.mdx
@@ -5,7 +5,7 @@ section: reference
 order: 3
 ---
 
-Pinax is MIT-licensed Go. Pull requests are welcome — the full contributor
+Pinax is MIT-licensed Go. Pull requests are welcome - the full contributor
 policy lives in [`CONTRIBUTING.md`](https://github.com/desmondsanctity/pinax/blob/main/CONTRIBUTING.md)
 and the code of conduct in [`CODE_OF_CONDUCT.md`](https://github.com/desmondsanctity/pinax/blob/main/CODE_OF_CONDUCT.md).
 This page is the short version.
@@ -74,5 +74,5 @@ Open an issue with:
 ## Security
 
 Don't open a public issue for vulnerabilities. Use [GitHub Security
-Advisories](https://github.com/desmondsanctity/pinax/security/advisories/new) — see [`SECURITY.md`](https://github.com/desmondsanctity/pinax/blob/main/SECURITY.md)
+Advisories](https://github.com/desmondsanctity/pinax/security/advisories/new) - see [`SECURITY.md`](https://github.com/desmondsanctity/pinax/blob/main/SECURITY.md)
 for the full policy.

--- a/website/src/content/docs/mcp-tools.mdx
+++ b/website/src/content/docs/mcp-tools.mdx
@@ -46,7 +46,7 @@ Returns URL paths grouped by top-level section with page counts:
 ]
 ```
 
-Cheap call — sections are derived from the manifest in memory.
+Cheap call - sections are derived from the manifest in memory.
 
 ## `search_pages`
 
@@ -106,7 +106,7 @@ the model wants to walk a topic exhaustively.
 
 Live-fetches the URL with `Accept: text/markdown` first, falls back to
 HTML extraction, and returns clean Markdown. The page cache is consulted
-first — entries older than the TTL trigger a refetch.
+first - entries older than the TTL trigger a refetch.
 
 `get_page` is the only tool that hits the network at call time. The
 others read from the in-memory manifest.

--- a/website/src/content/docs/mcp-tools.mdx
+++ b/website/src/content/docs/mcp-tools.mdx
@@ -1,0 +1,128 @@
+---
+title: MCP tools
+description: The five tools Pinax exposes, their argument shapes, and what they return.
+section: reference
+order: 1
+---
+
+A `pinax serve` instance exposes five MCP tools. Every tool except
+`list_docs` accepts an optional `docs` argument to scope the call to a
+single manifest when more than one is loaded. Omit `docs` to fan out
+across every manifest.
+
+## `list_docs`
+
+```jsonc
+{ "name": "list_docs", "arguments": {} }
+```
+
+Returns one entry per loaded manifest:
+
+```jsonc
+[
+  { "name": "stripe", "url": "https://docs.stripe.com", "pages": 412 },
+  { "name": "react", "url": "https://react.dev", "pages": 173 },
+]
+```
+
+Use it first if you don't already know what's mounted.
+
+## `list_sections`
+
+```jsonc
+{
+  "name": "list_sections",
+  "arguments": { "docs": "stripe" },
+}
+```
+
+Returns URL paths grouped by top-level section with page counts:
+
+```jsonc
+[
+  { "section": "/api", "pages": 138 },
+  { "section": "/payments", "pages": 67 },
+  { "section": "/billing", "pages": 41 },
+]
+```
+
+Cheap call — sections are derived from the manifest in memory.
+
+## `search_pages`
+
+```jsonc
+{
+  "name": "search_pages",
+  "arguments": {
+    "query": "payment intent confirm",
+    "limit": 10,
+    "docs": "stripe",
+  },
+}
+```
+
+BM25 ranked over URL paths, titles, and section names, with a substring +
+fuzzy fallback so typos still surface results. Returns:
+
+```jsonc
+[
+  {
+    "url": "https://docs.stripe.com/api/payment_intents/confirm",
+    "title": "Confirm a PaymentIntent",
+    "section": "/api/payment_intents",
+    "score": 0.84,
+  },
+]
+```
+
+Omit `docs` to search every loaded manifest in one shot. Results are
+interleaved by score, not grouped per docs site.
+
+## `get_section_pages`
+
+```jsonc
+{
+  "name": "get_section_pages",
+  "arguments": {
+    "section": "/api/payment_intents",
+    "docs": "stripe",
+  },
+}
+```
+
+Returns every page whose URL starts with that section prefix. Useful when
+the model wants to walk a topic exhaustively.
+
+## `get_page`
+
+```jsonc
+{
+  "name": "get_page",
+  "arguments": {
+    "url": "https://docs.stripe.com/api/payment_intents/confirm",
+  },
+}
+```
+
+Live-fetches the URL with `Accept: text/markdown` first, falls back to
+HTML extraction, and returns clean Markdown. The page cache is consulted
+first — entries older than the TTL trigger a refetch.
+
+`get_page` is the only tool that hits the network at call time. The
+others read from the in-memory manifest.
+
+## Error contract
+
+Every tool returns a structured error rather than throwing:
+
+```jsonc
+{
+  "error": {
+    "code": "not_found",
+    "message": "no manifest named 'striipe' (did you mean 'stripe'?)",
+  },
+}
+```
+
+Codes you'll see: `not_found`, `invalid_args`, `fetch_failed`,
+`cache_error`, `internal`.

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -6,8 +6,8 @@ order: 0
 ---
 
 Pinax is a single Go binary. Install it, point it at a docs site, then run
-`pinax serve`. Any MCP-compatible client — Claude Desktop, Claude Code,
-Cursor, Windsurf, Cline — can connect over stdio. No daemon, no cloud, no
+`pinax serve`. Any MCP-compatible client - Claude Desktop, Claude Code,
+Cursor, Windsurf, Cline - can connect over stdio. No daemon, no cloud, no
 re-indexing pipeline.
 
 ## 1. Install
@@ -36,7 +36,7 @@ Pick a name from the [catalog](/catalog):
 pinax add stripe
 ```
 
-Or point at any URL — anything containing `://`, a dot, or a slash is
+Or point at any URL - anything containing `://`, a dot, or a slash is
 treated as a URL:
 
 ```sh
@@ -70,7 +70,7 @@ That serves every indexed manifest at once. To pin a single one:
 pinax serve stripe
 ```
 
-Stdio is what MCP clients launch on demand — you usually don't run this in
+Stdio is what MCP clients launch on demand - you usually don't run this in
 a terminal, you point your client config at it. See [Serve](/docs/serve)
 for the HTTP transport + log UI.
 
@@ -97,6 +97,6 @@ for arg shapes and return contracts.
 
 ## Where to next
 
-- [Catalog](/docs/catalog) — what `pinax add <name>` resolves to and how to refresh.
-- [Serve](/docs/serve) — stdio vs HTTP and the log viewer.
-- [Troubleshooting](/docs/troubleshooting) — JS-rendered sites, doctor output, common errors.
+- [Catalog](/docs/catalog) - what `pinax add <name>` resolves to and how to refresh.
+- [Serve](/docs/serve) - stdio vs HTTP and the log viewer.
+- [Troubleshooting](/docs/troubleshooting) - JS-rendered sites, doctor output, common errors.

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -5,21 +5,98 @@ section: guides
 order: 0
 ---
 
-# Phase-0 stub
+Pinax is a single Go binary. Install it, point it at a docs site, then run
+`pinax serve`. Any MCP-compatible client — Claude Desktop, Claude Code,
+Cursor, Windsurf, Cline — can connect over stdio. No daemon, no cloud, no
+re-indexing pipeline.
 
-The real content for this page lands in **Phase 3** of `docs/SITE_PLAN.md`.
-For now this file exists so docs routing, the sidebar, and the layout shell
-can be exercised end-to-end.
+## 1. Install
 
-## What's here today
+The fastest path on macOS or Linux:
 
-- Astro 5 + Tailwind v4 + MDX + Svelte 5 (island framework, unused so far)
-- Cream `#FAF7F1` palette with ink-blue `#1E3A8A` accent
-- `/catalog` page that imports `internal/catalog/catalog.json` directly so
-  every entry stays in sync with the CLI
+```sh
+brew install desmondsanctity/tap/pinax
+```
 
-## What's next
+If you prefer Go:
 
-- Phase 1: hero, stats trio, how-it-works, install, FAQ
-- Phase 2: catalog filter + per-tag chips (Svelte island)
-- Phase 3: port the rest of the README into this docs collection
+```sh
+go install github.com/desmondsanctity/pinax/cmd/pinax@latest
+```
+
+Or grab a pre-built binary from the [releases page](https://github.com/desmondsanctity/pinax/releases)
+and drop it on your `$PATH`. The full matrix of install options lives in
+[Configuration](/docs/configuration).
+
+## 2. Index a docs site
+
+Pick a name from the [catalog](/catalog):
+
+```sh
+pinax add stripe
+```
+
+Or point at any URL — anything containing `://`, a dot, or a slash is
+treated as a URL:
+
+```sh
+pinax add https://docs.convex.dev
+```
+
+Pinax discovers pages via `llms.txt`, then sitemap, then a bounded BFS
+crawl, and writes an atomic JSON manifest plus a BM25 index under
+`~/.pinax/servers/<name>/`.
+
+## 3. List what's indexed
+
+```sh
+pinax list
+```
+
+You'll see every manifest with its page count, base URL, and last-refresh
+timestamp.
+
+## 4. Serve over stdio
+
+The same command works for every MCP-compatible client:
+
+```sh
+pinax serve
+```
+
+That serves every indexed manifest at once. To pin a single one:
+
+```sh
+pinax serve stripe
+```
+
+Stdio is what MCP clients launch on demand — you usually don't run this in
+a terminal, you point your client config at it. See [Serve](/docs/serve)
+for the HTTP transport + log UI.
+
+## 5. Connect a client
+
+Pick yours: [Claude Desktop](/docs/clients/claude-desktop) ·
+[Claude Code](/docs/clients/claude-code) ·
+[Cursor](/docs/clients/cursor) ·
+[Windsurf](/docs/clients/windsurf) ·
+[Cline](/docs/clients/cline).
+
+Or have Pinax print the snippet for you:
+
+```sh
+pinax config claude --project
+```
+
+## What you get
+
+Four tools, scoped to one manifest or every manifest at once:
+`list_sections`, `search_pages`, `get_section_pages`, `get_page`. Plus
+`list_docs` to enumerate what's loaded. See [MCP tools](/docs/mcp-tools)
+for arg shapes and return contracts.
+
+## Where to next
+
+- [Catalog](/docs/catalog) — what `pinax add <name>` resolves to and how to refresh.
+- [Serve](/docs/serve) — stdio vs HTTP and the log viewer.
+- [Troubleshooting](/docs/troubleshooting) — JS-rendered sites, doctor output, common errors.

--- a/website/src/content/docs/serve.mdx
+++ b/website/src/content/docs/serve.mdx
@@ -1,0 +1,63 @@
+---
+title: Serve
+description: stdio vs HTTP, the log viewer, port and host options.
+section: guides
+order: 2
+---
+
+`pinax serve` is the only command an MCP client ever actually launches. It
+mounts every manifest under `~/.pinax/servers/` as a single MCP server with
+five tools (`list_docs`, `list_sections`, `search_pages`,
+`get_section_pages`, `get_page`).
+
+## stdio (default)
+
+```sh
+pinax serve
+```
+
+Reads JSON-RPC from stdin and writes to stdout. This is what every MCP
+client launches when you wire up its config file. You almost never run this
+in a terminal yourself — point your client at it instead. See the per-client
+guides under [Clients](/docs/clients/claude-desktop).
+
+To pin a single manifest (useful for client-side resource hygiene):
+
+```sh
+pinax serve stripe
+```
+
+## HTTP + log UI
+
+```sh
+pinax serve --http --port 8423
+```
+
+Three endpoints are mounted:
+
+- `http://localhost:8423/` — dark-themed log viewer (every tool call your
+  agent makes, filterable per docs site).
+- `http://localhost:8423/mcp` — Streamable HTTP MCP endpoint.
+- `http://localhost:8423/sse` — legacy SSE endpoint for older clients.
+
+Use HTTP mode when you want to watch what an agent is actually doing.
+The log UI keeps history per-manifest and refreshes live.
+
+### Bind options
+
+| Flag     | Default     | What it does                               |
+| -------- | ----------- | ------------------------------------------ |
+| `--http` | off         | switches from stdio to HTTP transport      |
+| `--port` | `8423`      | TCP port for the HTTP listener             |
+| `--host` | `127.0.0.1` | bind address — keep on loopback by default |
+
+The MCP endpoints don't authenticate, so binding to anything other than
+`127.0.0.1` makes your indexed docs queryable by anyone on the network.
+
+## Unified mode
+
+In a single `pinax serve` call every tool takes an optional `docs`
+argument that scopes the call to one manifest. Omitting it searches across
+every loaded site at once. Call `list_docs` to discover what's loaded.
+
+See [MCP tools](/docs/mcp-tools) for the full tool contracts.

--- a/website/src/content/docs/serve.mdx
+++ b/website/src/content/docs/serve.mdx
@@ -18,7 +18,7 @@ pinax serve
 
 Reads JSON-RPC from stdin and writes to stdout. This is what every MCP
 client launches when you wire up its config file. You almost never run this
-in a terminal yourself — point your client at it instead. See the per-client
+in a terminal yourself - point your client at it instead. See the per-client
 guides under [Clients](/docs/clients/claude-desktop).
 
 To pin a single manifest (useful for client-side resource hygiene):
@@ -35,10 +35,10 @@ pinax serve --http --port 8423
 
 Three endpoints are mounted:
 
-- `http://localhost:8423/` — dark-themed log viewer (every tool call your
+- `http://localhost:8423/` - dark-themed log viewer (every tool call your
   agent makes, filterable per docs site).
-- `http://localhost:8423/mcp` — Streamable HTTP MCP endpoint.
-- `http://localhost:8423/sse` — legacy SSE endpoint for older clients.
+- `http://localhost:8423/mcp` - Streamable HTTP MCP endpoint.
+- `http://localhost:8423/sse` - legacy SSE endpoint for older clients.
 
 Use HTTP mode when you want to watch what an agent is actually doing.
 The log UI keeps history per-manifest and refreshes live.
@@ -49,7 +49,7 @@ The log UI keeps history per-manifest and refreshes live.
 | -------- | ----------- | ------------------------------------------ |
 | `--http` | off         | switches from stdio to HTTP transport      |
 | `--port` | `8423`      | TCP port for the HTTP listener             |
-| `--host` | `127.0.0.1` | bind address — keep on loopback by default |
+| `--host` | `127.0.0.1` | bind address - keep on loopback by default |
 
 The MCP endpoints don't authenticate, so binding to anything other than
 `127.0.0.1` makes your indexed docs queryable by anyone on the network.

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -31,8 +31,8 @@ For every manifest at once, omit the name.
 
 ## JS-rendered docs
 
-Pinax extracts the static HTML the server sends. Pure SPA shells — most
-React-router-only docs sites with no SSR — produce one-line pages that
+Pinax extracts the static HTML the server sends. Pure SPA shells - most
+React-router-only docs sites with no SSR - produce one-line pages that
 say "Loading…" and nothing else. Pinax tries to detect this and either:
 
 1. Switches to `llms.txt` if the site exposes one.
@@ -99,5 +99,5 @@ rm -rf ~/.pinax/servers/<name>
 pinax add <name>
 ```
 
-You won't lose anything except indexed manifests — the catalog is
+You won't lose anything except indexed manifests - the catalog is
 compiled into the binary.

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -1,0 +1,103 @@
+---
+title: Troubleshooting
+description: Doctor output, JS-rendered sites, thin pages, the content density gate, and the most common errors.
+section: guides
+order: 4
+---
+
+If `pinax add` worked but your agent gets unhelpful answers, the problem
+is usually one of three things: thin pages from a JS-rendered site, a
+manifest that's gone stale, or a search query that's hitting noise. This
+page walks each one.
+
+## Run `pinax doctor`
+
+```sh
+pinax doctor stripe
+```
+
+`doctor` re-scans the manifest and reports drift since the last refresh:
+page-count delta, mean prose length per page, fraction of pages that look
+empty (under 80 words), broken section anchors. Use it whenever queries
+suddenly return junk.
+
+For machine-readable output:
+
+```sh
+pinax doctor stripe --json
+```
+
+For every manifest at once, omit the name.
+
+## JS-rendered docs
+
+Pinax extracts the static HTML the server sends. Pure SPA shells — most
+React-router-only docs sites with no SSR — produce one-line pages that
+say "Loading…" and nothing else. Pinax tries to detect this and either:
+
+1. Switches to `llms.txt` if the site exposes one.
+2. Bails out at the preflight stage with a clear error.
+
+If your target site is JS-rendered but you _know_ the URLs are correct,
+try forcing a refresh with `--rebuild-index` so search uses whatever
+prose Pinax did manage to capture:
+
+```sh
+pinax refresh <name> --rebuild-index
+```
+
+Failing that, the site is genuinely SPA-only and Pinax v1 can't reach it.
+Open an issue with the URL.
+
+## The content-density preflight
+
+`pinax add` runs a one-shot preflight on the candidate URL before crawling:
+it fetches the homepage, strips chrome, and checks the prose ratio. If the
+ratio is too low it refuses to index, with a message naming the threshold.
+
+Bypass it when you know better:
+
+```sh
+pinax add <url> --no-preflight
+```
+
+`pinax doctor` will still flag thin pages after the fact.
+
+## "I added it but `search_pages` returns nothing"
+
+Three things to check, in order:
+
+1. Did `pinax add` actually finish? `pinax list` should show a page count
+   > 0.
+2. Is your query a token-AND substring? `payment intent` will match pages
+   containing both `payment` and `intent`. If neither token appears, the
+   fuzzy fallback kicks in but it's intentionally narrow.
+3. Are you scoping correctly? In a unified server, `search_pages` with no
+   `docs` arg searches across every manifest. Pass `docs: "stripe"` to
+   narrow.
+
+## Errors you might see
+
+| Message                                          | What it means                                                                  |
+| ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `preflight: density below threshold`             | The homepage looked like an SPA shell. Use `--no-preflight` to force.          |
+| `manifest <name> already exists`                 | Use `pinax refresh <name>` instead, or `pinax remove <name>` and re-add.       |
+| `discovery: no llms.txt, no sitemap, BFS failed` | The site has no machine-readable index and links are JS-only. Often unfixable. |
+| `get_page: 404`                                  | A URL drifted out of the docs site. Re-run `pinax refresh <name>`.             |
+| `cache: WAL checkpoint failed`                   | `~/.pinax/cache.db` is on a filesystem without proper locking. Move it.        |
+
+Most everything else surfaces with a context line; copy the full output
+into a GitHub issue with the URL you ran against.
+
+## Reset
+
+The nuclear option, when you want a clean slate:
+
+```sh
+pinax cache clear
+rm -rf ~/.pinax/servers/<name>
+pinax add <name>
+```
+
+You won't lose anything except indexed manifests — the catalog is
+compiled into the binary.

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -15,15 +15,6 @@ export const docsGroups: readonly DocsGroup[] = [
     ],
   },
   {
-    label: 'Reference',
-    items: [
-      { label: 'CLI', slug: 'cli' },
-      { label: 'MCP tools', slug: 'mcp-tools' },
-      { label: 'Architecture', slug: 'architecture' },
-      { label: 'Contributing', slug: 'contributing' },
-    ],
-  },
-  {
     label: 'Clients',
     items: [
       { label: 'Claude Desktop', slug: 'clients/claude-desktop' },
@@ -31,6 +22,15 @@ export const docsGroups: readonly DocsGroup[] = [
       { label: 'Cursor', slug: 'clients/cursor' },
       { label: 'Windsurf', slug: 'clients/windsurf' },
       { label: 'Cline', slug: 'clients/cline' },
+    ],
+  },
+  {
+    label: 'Reference',
+    items: [
+      { label: 'CLI', slug: 'cli' },
+      { label: 'MCP tools', slug: 'mcp-tools' },
+      { label: 'Architecture', slug: 'architecture' },
+      { label: 'Contributing', slug: 'contributing' },
     ],
   },
 ];

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -1,0 +1,43 @@
+export type DocsGroup = {
+  label: string;
+  items: readonly { label: string; slug: string }[];
+};
+
+export const docsGroups: readonly DocsGroup[] = [
+  {
+    label: 'Guides',
+    items: [
+      { label: 'Quick start', slug: 'quick-start' },
+      { label: 'Catalog', slug: 'catalog' },
+      { label: 'Serve', slug: 'serve' },
+      { label: 'Configuration', slug: 'configuration' },
+      { label: 'Troubleshooting', slug: 'troubleshooting' },
+    ],
+  },
+  {
+    label: 'Reference',
+    items: [
+      { label: 'CLI', slug: 'cli' },
+      { label: 'MCP tools', slug: 'mcp-tools' },
+      { label: 'Architecture', slug: 'architecture' },
+      { label: 'Contributing', slug: 'contributing' },
+    ],
+  },
+  {
+    label: 'Clients',
+    items: [
+      { label: 'Claude Desktop', slug: 'clients/claude-desktop' },
+      { label: 'Claude Code', slug: 'clients/claude-code' },
+      { label: 'Cursor', slug: 'clients/cursor' },
+      { label: 'Windsurf', slug: 'clients/windsurf' },
+      { label: 'Cline', slug: 'clients/cline' },
+    ],
+  },
+];
+
+export const docsOrder: readonly { label: string; slug: string; group: string }[] =
+  docsGroups.flatMap((g) => g.items.map((i) => ({ ...i, group: g.label })));
+
+export function groupForSlug(slug: string): string {
+  return docsOrder.find((d) => d.slug === slug)?.group ?? 'Guides';
+}

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -1,23 +1,48 @@
 ---
+import type { MarkdownHeading } from 'astro';
 import BaseLayout from './BaseLayout.astro';
 import Sidebar from '~/components/docs/Sidebar.astro';
+import Toc from '~/components/docs/Toc.astro';
+import Breadcrumb from '~/components/docs/Breadcrumb.astro';
+import EditOnGitHub from '~/components/docs/EditOnGitHub.astro';
+import PrevNext from '~/components/docs/PrevNext.astro';
+import DocsSearch from '~/components/docs/DocsSearch.svelte';
+import { groupForSlug } from '~/data/docsNav';
 
 type Props = {
   title: string;
   description?: string | undefined;
+  slug: string;
+  headings: readonly MarkdownHeading[];
 };
 
-const { title, description } = Astro.props;
+const { title, description, slug, headings } = Astro.props;
+const group = groupForSlug(slug);
 ---
 
 <BaseLayout title={title} description={description}>
-  <div class="container-page grid grid-cols-1 gap-10 py-10 lg:grid-cols-[14rem_minmax(0,1fr)]">
-    <aside class="lg:sticky lg:top-20 lg:self-start">
+  <div
+    class="container-page grid grid-cols-1 gap-10 py-10 lg:grid-cols-[14rem_minmax(0,1fr)_12rem]"
+  >
+    <aside class="lg:sticky lg:top-20 lg:self-start" data-pagefind-ignore>
+      <div class="mb-6">
+        <DocsSearch client:load />
+      </div>
       <Sidebar />
     </aside>
-    <article class="prose-pinax max-w-none">
-      <header class="mb-8 border-b pb-6" style="border-color: var(--color-hairline)">
-        <h1 class="text-4xl font-medium tracking-tight" style="color: var(--color-fg)">
+    <article class="prose-pinax max-w-none" data-pagefind-body>
+      <div data-pagefind-ignore class="mb-3">
+        <Breadcrumb group={group} title={title} />
+      </div>
+      <header
+        class="mb-8 border-b pb-6"
+        style="border-color: var(--color-hairline)"
+        data-pagefind-meta={`title:${title}`}
+      >
+        <h1
+          class="text-4xl font-medium tracking-tight"
+          style="color: var(--color-fg); font-family: var(--font-serif)"
+        >
           {title}
         </h1>
         {
@@ -29,6 +54,13 @@ const { title, description } = Astro.props;
         }
       </header>
       <slot />
+      <div data-pagefind-ignore class="mt-10">
+        <EditOnGitHub slug={slug} />
+        <PrevNext slug={slug} />
+      </div>
     </article>
+    <aside class="hidden lg:sticky lg:top-20 lg:block lg:self-start" data-pagefind-ignore>
+      <Toc headings={headings} />
+    </aside>
   </div>
 </BaseLayout>

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -12,9 +12,14 @@ export async function getStaticPaths() {
 
 type Props = { entry: CollectionEntry<'docs'> };
 const { entry } = Astro.props;
-const { Content } = await entry.render();
+const { Content, headings } = await entry.render();
 ---
 
-<DocsLayout title={entry.data.title} description={entry.data.description}>
+<DocsLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  slug={entry.slug}
+  headings={headings}
+>
   <Content />
 </DocsLayout>

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -143,3 +143,36 @@
   border-top: 1px solid var(--color-hairline);
   margin: 2rem 0;
 }
+.prose-pinax table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1.25rem;
+  font-size: 0.9rem;
+  display: block;
+  overflow-x: auto;
+}
+.prose-pinax thead {
+  background: var(--color-panel);
+}
+.prose-pinax th,
+.prose-pinax td {
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--color-hairline);
+  text-align: left;
+  vertical-align: top;
+}
+.prose-pinax th {
+  font-weight: 600;
+  color: var(--color-fg);
+  border-bottom-width: 2px;
+}
+.prose-pinax td {
+  color: var(--color-fg);
+}
+.prose-pinax tbody tr:last-child td {
+  border-bottom: 0;
+}
+.prose-pinax td code,
+.prose-pinax th code {
+  white-space: nowrap;
+}

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -122,11 +122,15 @@
   font-size: 0.88rem;
   border: 1px solid var(--color-hairline);
   margin-top: 1.25rem;
+  white-space: pre;
 }
 .prose-pinax pre code {
   background: transparent;
   padding: 0;
   font-size: inherit;
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
 }
 .prose-pinax strong {
   color: var(--color-fg);


### PR DESCRIPTION
This pull request adds several new documentation pages and refactors the documentation components to improve maintainability and navigation. The main changes include extracting navigation data into a shared module, introducing new components for breadcrumbs, edit links, and table of contents, and adding comprehensive documentation for Pinax's architecture, catalog, and CLI.

**Documentation content additions:**

* Added new documentation pages: `architecture.mdx`, `catalog.mdx`, and `cli.mdx`, providing detailed overviews of Pinax's architecture, catalog usage, and CLI commands. 

**Component and navigation refactoring:**

* Refactored sidebar navigation in `Sidebar.astro` to use `docsGroups` from a shared data module, improving maintainability and consistency. Updated navigation links to use slugs instead of hardcoded hrefs. 
* Added new components for documentation navigation and editing: `Breadcrumb.astro` for breadcrumbs, `PrevNext.astro` for previous/next page navigation, `EditOnGitHub.astro` for edit links, and `Toc.astro` for table of contents rendering.

**Search functionality:**

* Implemented a new `DocsSearch.svelte` component that provides a modal search dialog with keyboard shortcuts, result previews, and integration with Pagefind for fast client-side search.
